### PR TITLE
feat: add dynamic colours using caelestia color gen backend

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -6,12 +6,110 @@ Rectangle {
     id: root
     width: 1920
     height: 1080
-    color: "#131313"
+    color: mSurface
+
+    function toNumber(value, fallbackValue) {
+        var num = Number(value);
+        return isFinite(num) ? num : fallbackValue;
+    }
+
+    function boundedNumber(value, fallbackValue, minValue, maxValue) {
+        var num = toNumber(value, fallbackValue);
+
+        if (num < minValue) {
+            return minValue;
+        }
+
+        if (num > maxValue) {
+            return maxValue;
+        }
+
+        return num;
+    }
+
+    function toBool(value, fallbackValue) {
+        if (value === undefined || value === null || value === "") {
+            return fallbackValue;
+        }
+
+        var normalized = String(value).toLowerCase();
+        return normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on";
+    }
+
+    property string backgroundSource: {
+        var source = config.background ? config.background.toString().trim() : "";
+
+        if (!source || source.charAt(0) === "#") {
+            return "assets/background.png";
+        }
+
+        return source;
+    }
+    property string fontFamily: {
+        var availableFonts = Qt.fontFamilies();
+
+        function firstAvailable(candidates) {
+            for (var i = 0; i < candidates.length; i++) {
+                if (availableFonts.indexOf(candidates[i]) !== -1) {
+                    return candidates[i];
+                }
+            }
+            return "sans-serif";
+        }
+
+        var family = config.fontFamily;
+        if (!family || family === "") {
+            family = config.Font;
+        }
+
+        if (family && family !== "") {
+            family = family.toString().replace(/^"|"$/g, "");
+            if (availableFonts.indexOf(family) !== -1) {
+                return family;
+            }
+        }
+
+        return firstAvailable(["JetBrains Mono", "Rubik", "Noto Sans", "DejaVu Sans", "Sans"]);
+    }
+    property real baseFontSize: boundedNumber(config.FontSize, 12, 10, 24)
+    property real avatarBaseSize: boundedNumber(config.AvatarSize, 128, 64, 320)
+    property real avatarFrameSize: Math.max(96, Math.round(avatarBaseSize * 1.72))
+    property real avatarInset: Math.max(8, Math.round(avatarFrameSize * 0.09))
+    property bool dropShadows: toBool(config.dropShadows, false)
+    property real blurRadius: boundedNumber(config.blurRadius, 0, 0, 64)
+    property real cardOpacity: boundedNumber(config.cardOpacity, 0.95, 0.0, 1.0)
+    property real buttonRadius: boundedNumber(config.buttonRadius, 20, 0, 64)
+    property real passwordInputRadius: boundedNumber(config.passwordInputRadius, 20, 0, 64)
+    property real cardRadius: boundedNumber(config.cardRadius, 30, 0, 80)
+
+    property color mPrimary: config.mPrimary ? config.mPrimary : (config.accent ? config.accent : "#4cdadb")
+    property color mOnPrimary: config.mOnPrimary ? config.mOnPrimary : "#002022"
+    property color mSecondary: config.mSecondary ? config.mSecondary : "#95f4f5"
+    property color mOnSecondary: config.mOnSecondary ? config.mOnSecondary : "#003738"
+    property color mTertiary: config.mTertiary ? config.mTertiary : "#86d0ff"
+    property color mOnTertiary: config.mOnTertiary ? config.mOnTertiary : "#00344d"
+    property color mError: config.mError ? config.mError : (config.error ? config.error : "#ffb4ab")
+    property color mOnError: config.mOnError ? config.mOnError : "#690005"
+    property color mSurface: config.mSurface ? config.mSurface : (config.surface ? config.surface : "#131313")
+    property color mOnSurface: config.mOnSurface ? config.mOnSurface : (config.text ? config.text : "#e2e2e2")
+    property color mSurfaceVariant: config.mSurfaceVariant ? config.mSurfaceVariant : (config.surfaceVariant ? config.surfaceVariant : "#353535")
+    property color mOnSurfaceVariant: config.mOnSurfaceVariant ? config.mOnSurfaceVariant : (config.subtext ? config.subtext : "#919191")
+    property color mOutline: config.mOutline ? config.mOutline : "#7d7d7d"
+    property color mShadow: config.mShadow ? config.mShadow : "#000000"
+    property color mHover: config.mHover ? config.mHover : mPrimary
+    property color mOnHover: config.mOnHover ? config.mOnHover : mOnPrimary
+
+    property real overlayOpacity: 0.4
+    property real cardShadowOpacity: 0.55
+
+    function withAlpha(baseColor, alphaValue) {
+        return Qt.rgba(baseColor.r, baseColor.g, baseColor.b, alphaValue);
+    }
 
     Image {
         id: background
         anchors.fill: parent
-        source: "assets/background.png"
+        source: backgroundSource
         fillMode: Image.PreserveAspectCrop
 
         onStatusChanged: {
@@ -19,264 +117,285 @@ Rectangle {
                 console.log("Background missing, using fallback color");
             }
         }
-        Rectangle {
-            anchors.fill: parent
-            color: "#000000"
-            opacity: 0.4
-        }
     }
 
     Rectangle {
-        id: mainCard
+        anchors.fill: parent
+        color: mShadow
+        opacity: overlayOpacity
+    }
+
+    Item {
+        id: cardContainer
         width: 550
         height: 800
         anchors.centerIn: parent
-        radius: 30
-        border.color: "#BF4cdadb"
-        border.width: 1
 
-        gradient: Gradient {
-            GradientStop {
-                position: 0.5
-                color: "#BF1b1b1b"
-            }
-            GradientStop {
-                position: 1.0
-                color: "#BF4cdadb"
-            }
+        Rectangle {
+            anchors.fill: mainCard
+            anchors.leftMargin: 0
+            anchors.topMargin: 10
+            radius: cardRadius
+            color: withAlpha(mShadow, cardShadowOpacity)
+            visible: dropShadows
         }
 
-        ColumnLayout {
+        Rectangle {
+            id: mainCard
             anchors.fill: parent
-            anchors.margins: 40
-            spacing: 30
-
-            ColumnLayout {
-                Layout.alignment: Qt.AlignHCenter
-                spacing: 10
-                Text {
-                    id: clock
-                    Layout.alignment: Qt.AlignHCenter
-                    text: Qt.formatTime(new Date(), "hh:mm AP")
-                    style: Text.Outline
-                    styleColor: "#000000"
-                    font.pixelSize: 84
-                    font.family: "Rubik"
-                    color: "#e2e2e2"
-                }
-                Text {
-                    Layout.alignment: Qt.AlignHCenter
-                    text: Qt.formatDate(new Date(), "dddd, d MMMM yyyy")
-                    style: Text.Outline
-                    styleColor: "#000000"
-                    font.pixelSize: 22
-                    font.family: "Rubik"
-                    color: "#919191"
-                }
-            }
+            radius: cardRadius
+            border.color: withAlpha(mPrimary, cardOpacity)
+            border.width: 1
+            color: "transparent"
 
             Rectangle {
-                id: avatarFrame
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 220
-                Layout.preferredHeight: 220
-                radius: 110
-                color: "#BF131313"
-                border.color: "#4cdadb"
-                border.width: 2
-                clip: true
+                anchors.fill: parent
+                radius: cardRadius
+                opacity: cardOpacity
+                gradient: Gradient {
+                    GradientStop {
+                        position: 0.5
+                        color: withAlpha(mSurface, 0.92)
+                    }
+                    GradientStop {
+                        position: 1.0
+                        color: withAlpha(mPrimary, 0.36)
+                    }
+                }
+            }
 
-                Image {
-                    id: avatarImage
-                    anchors.fill: parent
-                    anchors.margins: 20
-                    fillMode: Image.PreserveAspectFit
-                    asynchronous: true
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 40
+                spacing: 30
 
-                    source: {
-                        if (userPicker.currentIndex !== -1) {
-                            var userName = userModel.data(userModel.index(userPicker.currentIndex, 0), Qt.UserRole + 1);
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 10
+                    Text {
+                        id: clock
+                        Layout.alignment: Qt.AlignHCenter
+                        text: Qt.formatTime(new Date(), "hh:mm AP")
+                        style: Text.Outline
+                        styleColor: mShadow
+                        font.pixelSize: Math.round(baseFontSize * 7)
+                        font.family: fontFamily
+                        color: mOnSurface
+                    }
+                    Text {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: Qt.formatDate(new Date(), "dddd, d MMMM yyyy")
+                        style: Text.Outline
+                        styleColor: mShadow
+                        font.pixelSize: Math.round(baseFontSize * 1.83)
+                        font.family: fontFamily
+                        color: mOnSurfaceVariant
+                    }
+                }
 
-                            var faceIcon = "file:///home/" + userName + "/.face.icon";
-                            var faceFile = "file:///home/" + userName + "/.face";
+                Rectangle {
+                    id: avatarFrame
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: avatarFrameSize
+                    Layout.preferredHeight: avatarFrameSize
+                    radius: avatarFrameSize / 2
+                    color: withAlpha(mSurface, cardOpacity)
+                    border.color: mPrimary
+                    border.width: 2
+                    clip: true
 
-                            var modelIcon = userModel.data(userModel.index(userPicker.currentIndex, 0), Qt.UserRole + 2);
+                    Image {
+                        id: avatarImage
+                        anchors.fill: parent
+                        anchors.margins: avatarInset
+                        fillMode: Image.PreserveAspectFit
+                        asynchronous: true
 
-                            if (modelIcon && modelIcon !== "") {
-                                return "file://" + modelIcon;
-                            } else {
-                                return faceIcon;
+                        source: {
+                            if (userPicker.currentIndex !== -1) {
+                                var userName = userModel.data(userModel.index(userPicker.currentIndex, 0), Qt.UserRole + 1);
+
+                                var faceIcon = "file:///home/" + userName + "/.face.icon";
+                                var faceFile = "file:///home/" + userName + "/.face";
+
+                                var modelIcon = userModel.data(userModel.index(userPicker.currentIndex, 0), Qt.UserRole + 2);
+
+                                if (modelIcon && modelIcon !== "") {
+                                    return "file://" + modelIcon;
+                                } else {
+                                    return faceIcon;
+                                }
+                            }
+                            return "assets/logo.png";
+                        }
+
+                        onStatusChanged: {
+                            if (status === Image.Error && source.toString().includes(".face.icon")) {
+                                var userName = userModel.data(userModel.index(userPicker.currentIndex, 0), Qt.UserRole + 1);
+                                source = "file:///home/" + userName + "/.face";
+                            } else if (status === Image.Error) {
+                                source = "assets/logo.png";
                             }
                         }
-                        return "assets/logo.png";
+                    }
+                }
+
+                ComboBox {
+                    id: userPicker
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: 380
+                    Layout.preferredHeight: 55
+                    model: userModel
+                    currentIndex: userModel.lastIndex
+                    textRole: "name"
+                    font.family: fontFamily
+                    font.pixelSize: Math.round(baseFontSize * 1.67)
+
+                    background: Rectangle {
+                        color: withAlpha(mSurface, cardOpacity)
+                        radius: passwordInputRadius
+                        border.color: mOutline
+                        border.width: 1
                     }
 
-                    onStatusChanged: {
-                        if (status === Image.Error && source.toString().includes(".face.icon")) {
-                            var userName = userModel.data(userModel.index(userPicker.currentIndex, 0), Qt.UserRole + 1);
-                            source = "file:///home/" + userName + "/.face";
-                        } else if (status === Image.Error) {
-                            source = "assets/logo.png";
+                    contentItem: Text {
+                        text: userPicker.displayText
+                        font: userPicker.font
+                        color: mOnSurface
+                        verticalAlignment: Text.AlignVCenter
+                        horizontalAlignment: Text.AlignHCenter
+                        leftPadding: 0
+                        rightPadding: 0
+                        topPadding: 0
+                        bottomPadding: 0
+
+                        anchors.fill: parent
+                    }
+
+                    indicator: Canvas {
+                        x: userPicker.width - 30
+                        y: (userPicker.height - 6) / 2
+                        width: 12
+                        height: 6
+                        onPaint: {
+                            var context = getContext("2d");
+                            context.reset();
+                            context.moveTo(0, 0);
+                            context.lineTo(width, 0);
+                            context.lineTo(width / 2, height);
+                            context.closePath();
+                            context.fillStyle = mPrimary;
+                            context.fill();
                         }
                     }
                 }
-            }
 
-            ComboBox {
-                id: userPicker
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 380
-                Layout.preferredHeight: 55
-                model: userModel
-                currentIndex: userModel.lastIndex
-                textRole: "name"
-                font.family: "Rubik"
-                font.pixelSize: 20
+                TextField {
+                    id: passwordField
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredWidth: 380
+                    Layout.preferredHeight: 55
+                    echoMode: TextInput.Password
+                    placeholderText: "Password"
+                    placeholderTextColor: mOnSurface
+                    font.family: fontFamily
+                    font.pixelSize: Math.round(baseFontSize * 1.83)
+                    color: mOnSurface
+                    horizontalAlignment: TextInput.AlignHCenter
 
-                background: Rectangle {
-                    color: "#BF131313"
-                    radius: 30
-                    border.color: "#353535"
-                    border.width: 1
+                    background: Rectangle {
+                        color: withAlpha(mSurface, cardOpacity)
+                        radius: passwordInputRadius
+                        border.color: passwordField.activeFocus ? mPrimary : mOutline
+                    }
+                    onAccepted: sddm.login(userPicker.currentText, text, sessionPicker.currentIndex)
                 }
 
-                contentItem: Text {
-                    text: userPicker.displayText
-                    font: userPicker.font
-                    color: "#e2e2e2"
-                    verticalAlignment: Text.AlignVCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    leftPadding: 0
-                    rightPadding: 0
-                    topPadding: 0
-                    bottomPadding: 0
+                Row {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 50
+                    Button {
+                        id: shutBtn
+                        onClicked: sddm.powerOff()
+                        background: Rectangle {
+                            radius: buttonRadius
+                            color: "transparent"
+                        }
+                        contentItem: Text {
 
-                    anchors.fill: parent
-                }
+                            text: "\ue8ac"
+                            font.family: "Material Symbols Outlined"
+                            font.pixelSize: Math.round(baseFontSize * 3.5)
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            color: shutBtn.hovered ? mError : mOnSurface
+                        }
+                    }
 
-                indicator: Canvas {
-                    x: userPicker.width - 30
-                    y: (userPicker.height - 6) / 2
-                    width: 12
-                    height: 6
-                    onPaint: {
-                        var context = getContext("2d");
-                        context.reset();
-                        context.moveTo(0, 0);
-                        context.lineTo(width, 0);
-                        context.lineTo(width / 2, height);
-                        context.closePath();
-                        context.fillStyle = "#4cdadb";
-                        context.fill();
+                    Button {
+                        id: rebBtn
+                        onClicked: sddm.reboot()
+                        background: Rectangle {
+                            radius: buttonRadius
+                            color: "transparent"
+                        }
+                        contentItem: Text {
+                            text: "\uf053"
+                            font.family: "Material Symbols Outlined"
+                            font.pixelSize: Math.round(baseFontSize * 3.5)
+                            horizontalAlignment: Text.AlignHCenter
+                            verticalAlignment: Text.AlignVCenter
+                            color: rebBtn.hovered ? mHover : mOnSurface
+                        }
                     }
                 }
-            }
 
-            TextField {
-                id: passwordField
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 380
-                Layout.preferredHeight: 55
-                echoMode: TextInput.Password
-                placeholderText: "Password"
-                placeholderTextColor: "#e2e2e2"
-                font.family: "Rubik"
-                font.pixelSize: 22
-                color: "#e2e2e2"
-                horizontalAlignment: TextInput.AlignHCenter
+                ComboBox {
+                    id: sessionPicker
+                    Layout.alignment: Qt.AlignHCenter
 
-                background: Rectangle {
-                    color: "#BF131313"
-                    radius: 35
-                    border.color: passwordField.activeFocus ? "#4cdadb" : "#353535"
-                }
-                onAccepted: sddm.login(userPicker.currentText, text, sessionPicker.currentIndex)
-            }
+                    implicitWidth: contentItem.implicitWidth + (indicator.width * 2) + 20
+                    Layout.preferredHeight: 40
 
-            Row {
-                Layout.alignment: Qt.AlignHCenter
-                spacing: 50
-                Button {
-                    id: shutBtn
-                    onClicked: sddm.powerOff()
-                    background: Item {}
+                    model: sessionModel
+                    currentIndex: sessionModel.lastIndex
+                    textRole: "name"
+                    font.family: fontFamily
+                    font.pixelSize: Math.round(baseFontSize * 1.5)
+
+                    background: Rectangle {
+                        color: withAlpha(mSurface, cardOpacity)
+                        radius: passwordInputRadius
+                        border.color: mOutline
+                        border.width: 1
+                    }
+
                     contentItem: Text {
-
-                        text: "\ue8ac"
-                        font.family: "Material Symbols Outlined"
-                        font.pixelSize: 42
-                        horizontalAlignment: Text.AlignHCenter
+                        text: sessionPicker.displayText
+                        font: sessionPicker.font
+                        color: mOnSurface
                         verticalAlignment: Text.AlignVCenter
-                        color: shutBtn.hovered ? "#ffb4ab" : "#e2e2e2"
-                    }
-                }
-
-                Button {
-                    id: rebBtn
-                    onClicked: sddm.reboot()
-                    background: Item {}
-                    contentItem: Text {
-                        text: "\uf053"
-                        font.family: "Material Symbols Outlined"
-                        font.pixelSize: 42
                         horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                        color: rebBtn.hovered ? "#4cdadb" : "#e2e2e2"
+                        leftPadding: 15
+                        rightPadding: 15
                     }
-                }
-            }
 
-            ComboBox {
-                id: sessionPicker
-                Layout.alignment: Qt.AlignHCenter
-
-                // 1. Remove fixed Layout.preferredWidth and use implicitWidth
-                implicitWidth: contentItem.implicitWidth + (indicator.width * 2) + 20
-                Layout.preferredHeight: 40
-
-                model: sessionModel
-                currentIndex: sessionModel.lastIndex
-                textRole: "name"
-                font.family: "Rubik"
-                font.pixelSize: 18
-
-                background: Rectangle {
-                    // The background will now naturally follow the ComboBox width
-                    color: "#BF131313"
-                    radius: 20
-                    border.color: "#353535"
-                    border.width: 1
-                }
-
-                contentItem: Text {
-                    // 2. Reference the displayText to calculate size
-                    text: sessionPicker.displayText
-                    font: sessionPicker.font
-                    color: "#e2e2e2"
-                    verticalAlignment: Text.AlignVCenter
-                    horizontalAlignment: Text.AlignHCenter
-
-                    // 3. Add horizontal padding so text isn't cramped
-                    leftPadding: 15
-                    rightPadding: 15
-                }
-
-                indicator: Canvas {
-                    id: canvas
-                    // 4. Anchor the arrow to the right side of the control
-                    x: sessionPicker.width - width - 10
-                    y: (sessionPicker.height - height) / 2
-                    width: 10
-                    height: 6
-                    onPaint: {
-                        var context = getContext("2d");
-                        context.reset();
-                        context.moveTo(0, 0);
-                        context.lineTo(width, 0);
-                        context.lineTo(width / 2, height);
-                        context.closePath();
-                        context.fillStyle = "#4cdadb";
-                        context.fill();
+                    indicator: Canvas {
+                        id: canvas
+                        x: sessionPicker.width - width - 10
+                        y: (sessionPicker.height - height) / 2
+                        width: 10
+                        height: 6
+                        onPaint: {
+                            var context = getContext("2d");
+                            context.reset();
+                            context.moveTo(0, 0);
+                            context.lineTo(width, 0);
+                            context.lineTo(width / 2, height);
+                            context.closePath();
+                            context.fillStyle = mPrimary;
+                            context.fill();
+                        }
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A sleek, obsidian-inspired login interface designed specifically for **Caelestia
 
 ## ✨ Features
 
-* **Obsidian UI:** Deep surfaces using `#131313` for a true dark-mode experience.
-* **Cyan Accents:** Interactive elements highlighted with Caelestia Cyan (`#4cdadb`).
+* **Dynamic Gradient UI:** Deep surfaces using dynamic colors.
+* **Dynamic Accents:** Interactive elements highlighted with Caelestia's dynamic primary color.
 * **Glassmorphism:** Translucent central card (80% opacity) for background integration.
 * **Optimized for Arch:** Lightweight QML implementation with Virtual Keyboard support.
 * **Smart Fallback:** Automatically uses system avatars or falls back to the Caelestia logo.
@@ -25,6 +25,12 @@ Edit /etc/sddm.conf (or /etc/sddm.conf.d/theme.conf):
 Current=caelestia
 ```
 
+### To sync wallpaper and colors
+```
+# run the sync script
+./sync.sh
+```
+
 ## 🧪 TESTING- Preview the theme without logging out
 
 `sddm-greeter --test-mode --theme /usr/share/sddm/themes/caelestia`
@@ -37,4 +43,5 @@ for everyone not on Caelestia Shell:
 * **SDDM** duh
 * **qt6-svg**
 * **qt6-virtualkeyboard**
-* **Rubik Font**
+* **JetBrains Mono Font** (preferred)
+* **Rubik Font** (fallback, optional)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Current=caelestia
 ./sync.sh
 ```
 
+## ⚙️ Configuration
+
+To customize the theme settings, you have two options:
+
+1. **Edit the template and reinstall:** Modify [theme.conf.template](theme.conf.template) in the source directory, then copy the theme again to `/usr/share/sddm/themes/caelestia`
+2. **Edit directly (recommended):** Modify `sddm-theme.conf` in your Caelestia config folder at `~/.config/caelestia/sddm-theme.conf` for changes that persist without reinstallation
+
 ## 🧪 TESTING- Preview the theme without logging out
 
 `sddm-greeter --test-mode --theme /usr/share/sddm/themes/caelestia`

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Simple script to check if the SDDM theme is installed correctly and if there are any issues with SDDM logs or configuration.
+
+echo "=== Checking SDDM Theme Installation ==="
+echo "Theme directory exists:"
+ls -la /usr/share/sddm/themes/caelestia/ 2>/dev/null && echo "✓ Found" || echo "✗ Missing"
+echo -e "\n=== Checking SDDM Config ==="
+if grep -rq "^Current=" /etc/sddm.conf /etc/sddm.conf.d/ 2>/dev/null; then
+    echo "✓ Found"
+else
+    echo "✗ Missing"
+fi
+echo -e "\n=== Checking Required Fonts ==="
+fc-list | grep -i "jetbrains mono" && echo "✓ JetBrains Mono" || echo "✗ JetBrains Mono missing"
+fc-list | grep -i "material" && echo "✓ Material font" || echo "✗ Material font missing"
+echo -e "\n=== Recent SDDM Errors ==="
+sudo journalctl -u sddm -b -0 --no-pager | grep -i "error\|warning\|fail" | tail -20

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,10 @@ THEME_NAME="caelestia"
 THEME_DIR="/usr/share/sddm/themes/$THEME_NAME"
 
 echo "Creating theme directory..."
+if [[ -d "$THEME_DIR" ]]; then
+    echo "Existing theme found, replacing it..."
+    sudo rm -rf "$THEME_DIR"
+fi
 sudo mkdir -p "$THEME_DIR"
 
 echo "Copying files to $THEME_DIR..."
@@ -11,11 +15,15 @@ sudo cp -r ./* "$THEME_DIR"
 
 sudo rm "$THEME_DIR/install.sh"
 
+echo "Creating template configuration..."
+mkdir -p "$HOME/.config/caelestia/templates"
+cp -r theme.conf.template "$HOME/.config/caelestia/templates/sddm-theme.conf"
+
 echo "------------------------------------------------"
 echo "Installation Complete!"
 echo "To enable, edit /etc/sddm.conf or /etc/sddm.conf.d/theme.conf"
 echo "Set: Current=$THEME_NAME"
-cat << "EOF"
+cat <<"EOF"
      ______           __          __  _       
     / ____/___ ____  / /__  _____/ /_(_)___ _ 
    / /   / __ `/ _ \/ / _ \/ ___/ __/ / __ `/ 

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Configuration
+SOURCE_WALLPAPER="$HOME/.local/state/caelestia/wallpaper/current"
+THEME_NAME="caelestia"
+THEME_DIR="/usr/share/sddm/themes/$THEME_NAME"
+
+# Sync wallpaper
+if [[ -f "$SOURCE_WALLPAPER" ]]; then
+  if [[ -d "$THEME_DIR/assets" ]]; then
+    echo "Syncing wallpaper into installed SDDM theme (requires sudo)..."
+    sudo cp "$SOURCE_WALLPAPER" "$THEME_DIR/assets/background.png"
+  else
+    echo "Installed theme directory not found, skipped wallpaper: $THEME_DIR"
+  fi
+else
+  echo "Wallpaper source not found, skipped: $SOURCE_WALLPAPER"
+fi
+
+# Sync theme config colors
+SOURCE_THEME_CONF="$HOME/.local/state/caelestia/theme/sddm-theme.conf"
+
+if [[ -f "$SOURCE_THEME_CONF" ]]; then
+  echo "Syncing theme.conf into installed SDDM theme (requires sudo)..."
+  sudo cp "$SOURCE_THEME_CONF" "$THEME_DIR/theme.conf"
+else
+  echo "Theme config not found, skipped: $SOURCE_THEME_CONF"
+fi
+
+echo "Sync complete."

--- a/theme.conf
+++ b/theme.conf
@@ -24,7 +24,6 @@ passwordInputRadius=20
 cardRadius=20
 
 # Default values
-Font="JetBrains Mono"
 FontSize=12
 AvatarSize=128
 

--- a/theme.conf.template
+++ b/theme.conf.template
@@ -30,26 +30,26 @@ AvatarSize=128
 
 # Color Scheme
 # Do not touch these!
-mPrimary=#4cdadb
-mOnPrimary=#002022
+mPrimary=#{{ primary.hex }}
+mOnPrimary=#{{ onPrimary.hex }}
 
-mSecondary=#95f4f5
-mOnSecondary=#003738
+mSecondary=#{{ secondary.hex }}
+mOnSecondary=#{{ onSecondary.hex }}
 
-mTertiary=#86d0ff
-mOnTertiary=#00344d
+mTertiary=#{{ tertiary.hex }}
+mOnTertiary=#{{ onTertiary.hex }}
 
-mError=#ffb4ab
-mOnError=#690005
+mError=#{{ error.hex }}
+mOnError=#{{ onError.hex }}
 
-mSurface=#131313
-mOnSurface=#e2e2e2
+mSurface=#{{ surface.hex }}
+mOnSurface=#{{ onSurface.hex }}
 
-mSurfaceVariant=#353535
-mOnSurfaceVariant=#919191
+mSurfaceVariant=#{{ surfaceVariant.hex }}
+mOnSurfaceVariant=#{{ onSurfaceVariant.hex }}
 
-mOutline=#7d7d7d
-mShadow=#000000
+mOutline=#{{ outline.hex }}
+mShadow=#{{ shadow.hex }}
 
-mHover=#4cdadb
-mOnHover=#002022
+mHover=#{{ primary.hex }}
+mOnHover=#{{ onPrimary.hex }}

--- a/theme.conf.template
+++ b/theme.conf.template
@@ -24,7 +24,6 @@ passwordInputRadius=20
 cardRadius=20
 
 # Default values
-Font="JetBrains Mono"
 FontSize=12
 AvatarSize=128
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+THEME_NAME="caelestia"
+THEME_DIR="/usr/share/sddm/themes/$THEME_NAME"
+TEMPLATE_FILE="$HOME/.config/caelestia/templates/sddm-theme.conf"
+TEMPLATE_DIR="$HOME/.config/caelestia/templates"
+
+# Remove the sddm theme
+echo "Removing SDDM theme from $THEME_DIR..."
+if [[ -d "$THEME_DIR" ]]; then
+    sudo rm -rf "$THEME_DIR"
+    echo "Removed theme directory."
+else
+    echo "Theme directory not found, skipped."
+fi
+
+# Remove the template configuration
+echo "Removing template file from $TEMPLATE_FILE..."
+if [[ -f "$TEMPLATE_FILE" ]]; then
+    rm -f "$TEMPLATE_FILE"
+    echo "Removed template file."
+else
+    echo "Template file not found, skipped."
+fi
+
+if [[ -d "$TEMPLATE_DIR" ]] && [[ -z "$(ls -A "$TEMPLATE_DIR")" ]]; then
+    rmdir "$TEMPLATE_DIR"
+    echo "Removed empty template directory."
+fi
+
+echo "Uninstall complete."


### PR DESCRIPTION
Introduce dynamic colors for the Caelestia SDDM theme using a Caelestia's color generation backend and added stylings configurations.

### What changed
- Added dynamic Material You style color bindings (`m*` keys) in `Main.qml`.
- Added configurable stylings such as fonts, rounding, blurs, avatar size in theme config.
- Improve install script
- Added uninstall script and check script to make sure its installed correctly
- Modified README.md instructions