### PR TITLE
fix: layout overflow on non-1080p screens + quotesModel crash

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -2,7 +2,7 @@
 set -o pipefail
 
 THEME_DIR="/usr/share/sddm/themes/caelestia"
-REAL_USER=$(ls /home | grep -v "lost+found" | head -n 1)
+REAL_USER=${SUDO_USER:-$(ls /home | grep -v "lost+found" | head -n 1)}
 REAL_HOME="/home/$REAL_USER"
 CAEL_STATE="$REAL_HOME/.local/state/caelestia"
 

--- a/themes/locklike/Main.qml
+++ b/themes/locklike/Main.qml
@@ -209,7 +209,7 @@ Rectangle {
                 Rectangle {
                     id: topLeftRect
                     width: 365
-                    height: root.height / 6
+                    height: 180
                     color: config.subComponents
                     topLeftRadius: mainCard.radius / 2
                     radius: mainCard.radius / 4
@@ -258,8 +258,8 @@ Rectangle {
 
                 Rectangle {
                     id: middleLeftRect
-                    width: 365 
-                    height: root.height / 3.2
+                    width: 365
+                    Layout.fillHeight: true
                     color: config.subComponents
                     radius: mainCard.radius / 4
                     clip: true
@@ -382,7 +382,7 @@ Rectangle {
                 Rectangle {
                     id: bottomLeftRect
                     width: 365 
-                    height: root.height / 6
+                    height: 180
                     color: config.subComponents
                     bottomLeftRadius: mainCard.radius / 2
                     radius: mainCard.radius / 4

--- a/themes/locklike/components/RandomQuote.qml
+++ b/themes/locklike/components/RandomQuote.qml
@@ -5,7 +5,6 @@ Item {
     anchors.fill: parent 
     property alias color: quote.color 
     property alias maxWidth: quote.width
-    property int index: Math.floor(Math.random() * quotesModel.count)
     Item {
         Component.onCompleted: {
             const xhr = new XMLHttpRequest()


### PR DESCRIPTION
## What this fixes

**1. `quotesModel is not defined` crash (RandomQuote.qml)**

Leftover line from the old ListModel-based quotes approach:
```qml
property int index: Math.floor(Math.random() * quotesModel.count)
```
`quotesModel` no longer exists (quotes load via XHR now), so it crashes on startup. Removed the line.

**2. Left column panels overflow the card on non-1080p screens (Main.qml)**

`topLeftRect`, `middleLeftRect`, and `bottomLeftRect` use `root.height / 6` and `root.height / 3.2` for their heights. SDDM resizes the root item to match the actual screen, so on a 3440x1440 display `root.height` becomes 1440 - the three panels sum to ~950px while `mainCard` is hardcoded at 750px. The right column is fine because it uses hardcoded heights.

Fixed by replacing the `root.height` fractions with a fixed `180px` for top/bottom panels and `Layout.fillHeight: true` for the middle one.

**3. Wrong user detected on multi-user systems (sync.sh)**

`sync.sh` picks the user with `ls /home | head -n 1`, which breaks when there are multiple entries in `/home`. Fixed by preferring `$SUDO_USER` when available (which is always set when running via `caelestia-sync.service`).