### PR TITLE
feat: enhance sync to generate colors beforehand.

### DIFF
--- a/POSTHOOK.md
+++ b/POSTHOOK.md
@@ -8,7 +8,7 @@ Edit `~/.config/caelestia/cli.json` and set:
 
 ```json
 "wallpaper": {
-    "postHook": "sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh"
+    "postHook": "sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh --posthook"
 }
 ```
 If you dont have `cli.json` file setup, get them from (Under "Example Configuration"):

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ If you want a fully automated sync without reboot, use posthook. See **[POSTHOOK
 To customize the theme config, modify it only through the Caelestia config:
 
 1. Edit `~/.config/caelestia/sddm-theme.conf`
-2. Select a wallpaper (to trigger color generation)
 2. Apply sync:
    ```bash
    sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,7 +135,7 @@ fi
 sudo chown -R root:root "$INSTALL_DIR"
 sudo chmod -R 755 "$INSTALL_DIR"
 sudo chmod -R 777 "$INSTALL_DIR/assets"
-sudo chmod 666 "$INSTALL_DIR/theme.conf"
+sudo chmod 644 "$INSTALL_DIR/theme.conf"
 sudo chmod +x "$INSTALL_DIR/scripts/sync.sh"
 
 #5. Set the Current theme to Caelestia in SDDM configuration
@@ -163,6 +163,12 @@ echo -e "[Theme]\nCurrent=caelestia" | sudo tee /etc/sddm.conf.d/caelestia.conf 
 echo "✓ Created /etc/sddm.conf.d/caelestia.conf"
 
 
+# 6. Run sync script
+echo "Running initial sync..."
+sudo "$INSTALL_DIR/scripts/sync.sh"
+echo "✓ Initial sync complete"
+
+echo ""
 echo "✅ Installation Complete!"
 echo "Set: Current=$THEME_NAME"
 cat <<"EOF"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -6,7 +6,27 @@ REAL_USER=${SUDO_USER:-$(ls /home | grep -v "lost+found" | head -n 1)}
 REAL_HOME="/home/$REAL_USER"
 CAEL_STATE="$REAL_HOME/.local/state/caelestia"
 
-# 1. Sync avatar files into theme assets so sddm can safely access them without permission issues.
+# 1. Generate colors from the current Caelestia scheme settings FIRST
+if [ "$1" = "--posthook" ]; then
+    : # Skip color generation when run as posthook (--posthook)
+    echo "✓ Running as posthook, skipping color generation"
+elif command -v caelestia &>/dev/null; then
+    export HOME="$REAL_HOME" XDG_CONFIG_HOME="$REAL_HOME/.config" XDG_DATA_HOME="$REAL_HOME/.local/share" XDG_STATE_HOME="$REAL_HOME/.local/state"
+    mapfile -t SCHEME < <(caelestia scheme get --name --mode --variant 2>/dev/null)
+    NAME="${SCHEME[0]}"
+    MODE="${SCHEME[1]}"
+    VARIANT="${SCHEME[2]}"
+    if [ -n "$NAME" ] && [ -n "$MODE" ] && [ -n "$VARIANT" ]; then
+        caelestia scheme set --name "$NAME" --mode "$MODE" --variant "$VARIANT" 2>/dev/null
+        echo "✓ Generated colors for scheme: $NAME/$MODE/$VARIANT"
+    else
+        echo "Could not read Caelestia scheme, skipping color generation"
+    fi
+else
+    echo "Caelestia CLI not found, skipping color generation"
+fi
+
+# 2. Sync avatar files into theme assets so sddm can safely access them without permission issues.
 if [ -f "$REAL_HOME/.face.icon" ]; then
     cp -f "$REAL_HOME/.face.icon" "$THEME_DIR/assets/avatar.face.icon"
     chmod 644 "$THEME_DIR/assets/avatar.face.icon"
@@ -23,13 +43,13 @@ else
     rm -f "$THEME_DIR/assets/avatar.face"
 fi
 
-# 2. Sync Colors
+# 3. Sync Colors
 if [ -f "$CAEL_STATE/theme/sddm-theme.conf" ]; then
     cp -f "$CAEL_STATE/theme/sddm-theme.conf" "$THEME_DIR/theme.conf"
     chmod 644 "$THEME_DIR/theme.conf"
 fi
 
-# 3. Sync Wallpaper LAST
+# 4. Sync Wallpaper LAST
 if [[ -f "$CAEL_STATE/wallpaper/current" ]]; then
     # Detect extension and handle symlinks
     FILENAME=$(basename "$(readlink -f "$CAEL_STATE/wallpaper/current")")


### PR DESCRIPTION
**Changes:**
- sync script now always generates fresh colors beforehand.
- sync script can be run with `--posthook` flag to skip color generation.
- install script runs sync after installation is done.

**NOTE BREAKING CHANGE, posthook now should be run like so:**
```
"wallpaper": {
    "postHook": "sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh --posthook"
 },
```

This fixes issues with broken colors when changing themes as fresh colors are always generated, also now no need to change wallpaper then run sync script if not using posthook.