### PR TITLE
feat: enhance light theme support

### DIFF
--- a/themes/locklike/Main.qml
+++ b/themes/locklike/Main.qml
@@ -78,10 +78,16 @@ Rectangle {
             }
             layer.enabled: true
             layer.effect: DropShadow {
-                color: "#80000000"
+                color: Qt.rgba(
+                    parseInt(config.background.substring(1,3), 16)/255,
+                    parseInt(config.background.substring(3,5), 16)/255,
+                    parseInt(config.background.substring(5,7), 16)/255,
+                    0.5
+                )
                 horizontalOffset: 0
                 verticalOffset: 0
-                radius: 8
+                radius: 16
+                scale: 1.5
             }
         }
         Text{
@@ -90,10 +96,10 @@ Rectangle {
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 20
             font.family: "Rubik"
-            font.pointSize: 18
+            font.pointSize: 15
             font.italic: true
             opacity: root.firstInput ? 1.0 : 0.0
-            color: "#c4c7c6"
+            color: config.text
             text: "Press a key on your Keyboard to login"
 
             Behavior on opacity{
@@ -229,7 +235,7 @@ Rectangle {
                     }
                     Text {
                         renderType: Text.NativeRendering
-                        width: topLeftRect.width - 40 
+                        width: topLeftRect.width - 40
 
                         text: "<span style='color:" + config.text + ";'>" 
                             + topLeftRect.welcomeString + " </span>"
@@ -278,7 +284,7 @@ Rectangle {
                             color: "#111111"
                             text: ">"
                             font.family: "CaskaydiaCove NF"
-                            font.pointSize: 15 
+                            font.pointSize: 15
                         }
                     }
                     ColumnLayout {
@@ -504,8 +510,6 @@ Rectangle {
                         renderType: Text.NativeRendering
                         Layout.alignment: Qt.AlignHCenter
                         text: Qt.formatDate(new Date(), "dddd,   d  MMMM  yyyy")
-                        style: Text.Outline
-                        styleColor: "#000000"
                         font.pixelSize: 28
                         font.family: "Rubik"
                         font.bold: false
@@ -603,7 +607,7 @@ Rectangle {
                                     radius: 30
                                     width: 12
                                     height: 12
-                                    color: "white"
+                                    color: config.text
                                 }
 
                             }
@@ -613,7 +617,7 @@ Rectangle {
                                 visible: root.buffer === "" ? false: true
                                 width: 1 
                                 height: 21
-                                color: "white"
+                                color: config.text
                                 opacity: invisible ? 0 : 1
                                 Behavior on opacity{NumberAnimation{duration: 200}}
                                 Timer {

--- a/themes/minimalist/Main.qml
+++ b/themes/minimalist/Main.qml
@@ -199,7 +199,7 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 30
         font.family: Theme.fontFamily
-        font.pixelSize: Math.round(Theme.baseFontSize * 1.5)
+        font.pixelSize: Math.round(Theme.baseFontSize * 1.8)
         font.italic: true
         opacity: root.firstInput ? 1 : 0
         color: Theme.mOnSurfaceVariant

--- a/themes/minimalist/components/WelcomeHeading.qml
+++ b/themes/minimalist/components/WelcomeHeading.qml
@@ -25,7 +25,7 @@ Text {
         verticalOffset: 6
         radius: 24
         samples: 40
-        color: Theme.withAlpha(Theme.mShadow, 0.65)
+        color: Theme.withAlpha(Theme.mSurface, 0.65)
     }
 
     Behavior on opacity {

--- a/themes/minimalistV2/Main.qml
+++ b/themes/minimalistV2/Main.qml
@@ -199,7 +199,7 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 30
         font.family: Theme.fontFamily
-        font.pixelSize: Math.round(Theme.baseFontSize * 1.5)
+        font.pixelSize: Math.round(Theme.baseFontSize * 1.8)
         font.italic: true
         opacity: root.firstInput ? 1 : 0
         color: Theme.mOnSurfaceVariant

--- a/themes/minimalistV2/components/WelcomeHeading.qml
+++ b/themes/minimalistV2/components/WelcomeHeading.qml
@@ -25,7 +25,7 @@ Text {
         verticalOffset: 6
         radius: 24
         samples: 40
-        color: Theme.withAlpha(Theme.mShadow, 0.65)
+        color: Theme.withAlpha(Theme.mSurface, 0.65)
     }
 
     Behavior on opacity {


### PR DESCRIPTION
**For locklike:**
before:
<img width="1917" height="1077" alt="image" src="https://github.com/user-attachments/assets/6293d164-8c34-4666-9b1d-6c1e98913d18" />

After:
<img width="1918" height="1076" alt="image" src="https://github.com/user-attachments/assets/8fcc2d2e-43b4-48a2-a2d1-cf7b3d925652" />

- texts now use proper config.text colors.
- remove weird border on date text to prevent jagged lines on light background.
- make welcome message dropshadow use config.background colors.

**For minimalists:**
- improve drop shadow color mapping on welcome message.