### PR TITLE
fix: correct powerOff() method name in Main.qml

### DIFF
--- a/themes/locklike/Main.qml
+++ b/themes/locklike/Main.qml
@@ -440,7 +440,7 @@ Rectangle {
                             anchors.fill: parent
 
                             onClicked: {
-                                sddm.poweroff();
+                                sddm.powerOff();
                             }
                         }
                     }


### PR DESCRIPTION
\`sddm.poweroff()\` is not a valid function in the current SDDM API.
The correct camelCase method is \`sddm.powerOff()\`.

This caused the greeter to crash on shutdown/reboot with:
\`\`\`
TypeError: Property 'poweroff' of object SDDM::GreeterProxy is not a function
\`\`\`