### PR TITLE
fix: Improve script safety and clean some stuffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,14 @@ QML_XHR_ALLOW_FILE_READ=1 sddm-greeter-qt6 --test-mode --theme /usr/share/sddm/t
 **Avatar not updating or showing stale image**
 
 ```bash
-sudo ./scripts/fix-avatar.sh
+./scripts/fix-avatar.sh
 ```
 
-This keeps `~/.face.icon` synced to `~/.face` and fixes incorrect avatar images.
+**Caelestia dots, states and config files being owned by root**
+
+```bash
+./scripts/fix-permissions.sh
+```
 
 ## Requirements
 

--- a/scripts/fix-avatar.sh
+++ b/scripts/fix-avatar.sh
@@ -1,80 +1,46 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TARGET_USER="${1:-${SUDO_USER:-$USER}}"
-
-if ! id "$TARGET_USER" >/dev/null 2>&1; then
-    echo "[FAIL] User not found: $TARGET_USER"
+# Prevent running with sudo - the script uses sudo internally for some commands
+if [ "$(id -u)" -eq 0 ]; then
+    echo "ERROR: Do not run this script with sudo. Run it normally." >&2
     exit 1
 fi
 
-TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
-if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
-    echo "[FAIL] Could not resolve home directory for $TARGET_USER"
-    exit 1
-fi
+REAL_USER="${SUDO_USER:-$(whoami)}"
+REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
 
-FACE_FILE="$TARGET_HOME/.face"
-FACE_ICON_FILE="$TARGET_HOME/.face.icon"
+FACE_FILE="$REAL_HOME/.face"
+FACE_ICON_FILE="$REAL_HOME/.face.icon"
 BACKUP_SUFFIX="$(date +%Y%m%d-%H%M%S)"
 
-is_root() {
-    [ "${EUID:-$(id -u)}" -eq 0 ]
-}
-
-ensure_owner() {
-    local path="$1"
-    if is_root; then
-        chown "$TARGET_USER:$TARGET_USER" "$path"
-    else
-        local owner
-        owner="$(stat -c '%U' "$path")"
-        if [ "$owner" != "$TARGET_USER" ]; then
-            echo "[FAIL] $path is owned by $owner (expected $TARGET_USER). Re-run with sudo."
-            exit 1
-        fi
-    fi
-}
-
-echo "=== Fixing avatar files for $TARGET_USER ==="
-
 if [ ! -f "$FACE_FILE" ]; then
-    echo "[FAIL] Missing $FACE_FILE"
-    echo "Create .face first, then run this script again."
+    echo "✗ Missing $FACE_FILE — create .face first, then run this script again." >&2
     exit 1
 fi
 
-ensure_owner "$FACE_FILE"
+sudo chown "$REAL_USER:$REAL_USER" "$FACE_FILE"
 chmod 644 "$FACE_FILE"
-echo "[OK] Fixed ownership and permissions on $FACE_FILE"
+echo "✓ Fixed ownership and permissions on $FACE_FILE"
 
 if [ -L "$FACE_ICON_FILE" ]; then
     link_target="$(readlink "$FACE_ICON_FILE")"
-    if [ "$link_target" = ".face" ] || [ "$link_target" = "$FACE_FILE" ]; then
-        echo "[OK] $FACE_ICON_FILE already points to .face"
-    else
+    if [ "$link_target" != ".face" ] && [ "$link_target" != "$FACE_FILE" ]; then
         mv "$FACE_ICON_FILE" "${FACE_ICON_FILE}.backup-${BACKUP_SUFFIX}"
         ln -s .face "$FACE_ICON_FILE"
-        echo "[OK] Replaced old symlink target and pointed $FACE_ICON_FILE -> .face"
+        echo "✓ Replaced symlink $FACE_ICON_FILE -> .face"
     fi
 elif [ -e "$FACE_ICON_FILE" ]; then
     mv "$FACE_ICON_FILE" "${FACE_ICON_FILE}.backup-${BACKUP_SUFFIX}"
     ln -s .face "$FACE_ICON_FILE"
-    echo "[OK] Backed up old file and created $FACE_ICON_FILE -> .face"
+    echo "✓ Backed up old file and created $FACE_ICON_FILE -> .face"
 else
     ln -s .face "$FACE_ICON_FILE"
-    echo "[OK] Created $FACE_ICON_FILE -> .face"
+    echo "✓ Created $FACE_ICON_FILE -> .face"
 fi
+
+sudo chown -h "$REAL_USER:$REAL_USER" "$FACE_ICON_FILE"
 
 if [ -e "$FACE_ICON_FILE" ] && [ ! -L "$FACE_ICON_FILE" ]; then
-    ensure_owner "$FACE_ICON_FILE"
     chmod 644 "$FACE_ICON_FILE"
 fi
-
-if is_root; then
-    chown -h "$TARGET_USER:$TARGET_USER" "$FACE_ICON_FILE"
-fi
-
-echo
-echo "Done. Current state:"
-ls -l "$FACE_FILE" "$FACE_ICON_FILE"

--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$(id -u)" -eq 0 ] && [ -z "${SUDO_USER:-}" ]; then
-    echo "ERROR: Do not run this as root directly. Run as: sudo $0" >&2
+# This doesnt require sudo, but still has safeguard
+if [ "$(id -u)" -eq 0 ]; then
+    echo "ERROR: Do not run this script with sudo. Run it normally." >&2
     exit 1
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+# Prevent running with sudo - the script uses sudo internally for some commands
+if [ "$(id -u)" -eq 0 ]; then
+    echo "ERROR: Do not run this script with sudo. Run it normally." >&2
+    exit 1
+fi
 
 # Dynamically find the project root regardless of where this script is called from
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -117,36 +123,24 @@ echo "✓ Copied theme '$SELECTED_THEME' to $INSTALL_DIR"
 # 2. Create template configuration in user's home directory
 echo "Creating color template configuration..."
 mkdir -p "$HOME/.config/caelestia/templates"
-cp "$THEME_SOURCE/theme.conf.template" "$HOME/.config/caelestia/templates/sddm-theme.conf"
-echo "✓ Template created at ~/.config/caelestia/templates/sddm-theme.conf"
+if [ -f "$THEME_SOURCE/theme.conf.template" ]; then
+    cp "$THEME_SOURCE/theme.conf.template" "$HOME/.config/caelestia/templates/sddm-theme.conf"
+    echo "✓ Template created at ~/.config/caelestia/templates/sddm-theme.conf"
+else
+    echo "No theme.conf.template found, skipping template creation"
+fi
 
 # 3. Fix permissions so sync.sh have proper root access
 sudo chown -R root:root "$INSTALL_DIR"
 sudo chmod -R 755 "$INSTALL_DIR"
-sudo chmod -R 777 "$INSTALL_DIR/assets"
+if [ -d "$INSTALL_DIR/assets" ]; then
+    sudo find "$INSTALL_DIR/assets" -type d -exec chmod 755 {} \;
+    sudo find "$INSTALL_DIR/assets" -type f -exec chmod 644 {} \;
+fi
 sudo chmod 644 "$INSTALL_DIR/theme.conf"
 sudo chmod +x "$INSTALL_DIR/scripts/sync.sh"
 
-#4. Set the Current theme to Caelestia in SDDM configuration
-# Force Current theme in all possible config locations
-for config in /usr/lib/sddm/sddm.conf.d/default.conf; do
-    if [ -f "$config" ]; then
-        sudo sed -i 's/^Current=.*/Current=caelestia/' "$config"
-    fi
-done
-
-# Handle /etc/sddm.conf - create or update
-if [ -f /etc/sddm.conf ]; then
-    # File exists, update the Current setting
-    sudo sed -i 's/^Current=.*/Current=caelestia/' /etc/sddm.conf
-    echo "✓ Updated /etc/sddm.conf"
-else
-    # File doesn't exist, create it
-    echo -e "[Theme]\nCurrent=caelestia" | sudo tee /etc/sddm.conf > /dev/null
-    echo "✓ Created /etc/sddm.conf"
-fi
-
-# Ensure the drop-in exists too
+#4. Set the Current theme via drop-in only
 sudo mkdir -p /etc/sddm.conf.d
 cat <<'DROPIN' | sudo tee /etc/sddm.conf.d/caelestia.conf > /dev/null
 [General]
@@ -156,7 +150,6 @@ GreeterEnvironment=QML_XHR_ALLOW_FILE_READ=1
 Current=caelestia
 DROPIN
 echo "✓ Created /etc/sddm.conf.d/caelestia.conf"
-
 
 # 5. Run sync script
 echo "Running initial sync..."

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
-set -o pipefail
+set -euo pipefail
 
-THEME_DIR="/usr/share/sddm/themes/caelestia"
-
+# Get the real user and home directory
 if [ -n "$SUDO_USER" ]; then
     REAL_USER="$SUDO_USER"
 else
-    echo "ERROR: Cannot determine target user. Run with sudo." >&2
+    echo "ERROR: Cannot determine target user. Try running with sudo." >&2
     exit 1
 fi
 REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
-
 CAEL_STATE="$REAL_HOME/.local/state/caelestia"
+THEME_DIR="/usr/share/sddm/themes/caelestia"
 
 # 1. Generate FRESH colors from the current Caelestia scheme settings FIRST
-if [ "$1" = "--posthook" ]; then
+if [ "${1:-}" = "--posthook" ]; then
     : # Skip color generation when run as posthook (--posthook)
     echo "✓ Running as posthook, skipping color generation"
 elif command -v caelestia &>/dev/null; then
+    # IMPORTANT: must use sudo -u here
     mapfile -t SCHEME < <(sudo -u "$REAL_USER" caelestia scheme get --name --mode --variant 2>/dev/null)
     NAME="${SCHEME[0]}"
     MODE="${SCHEME[1]}"
     VARIANT="${SCHEME[2]}"
     if [ -n "$NAME" ] && [ -n "$MODE" ] && [ -n "$VARIANT" ]; then
+        # and here
         sudo -u "$REAL_USER" caelestia scheme set --name "$NAME" --mode "$MODE" --variant "$VARIANT" 2>/dev/null
         echo "✓ Generated colors for scheme: $NAME/$MODE/$VARIANT"
     else

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,13 +1,27 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
+
+# Prevent running with sudo - the script uses sudo internally for some commands
+if [ "$(id -u)" -eq 0 ]; then
+    echo "ERROR: Do not run this script with sudo. Run it normally." >&2
+    exit 1
+fi
 
 THEME_NAME="caelestia"
 THEME_DIR="/usr/share/sddm/themes/$THEME_NAME"
 TEMPLATE_FILE="$HOME/.config/caelestia/templates/sddm-theme.conf"
 TEMPLATE_DIR="$HOME/.config/caelestia/templates"
 
-echo "Uninstalling Caelestia SDDM Theme..."
+# --- Sudo check ---
+echo "Caelestia SDDM Theme Uninstaller"
+echo "This script requires sudo privileges to remove the theme."
+echo ""
+if ! sudo -v; then
+    echo "✗ Sudo authentication failed. Exiting."
+    exit 1
+fi
+echo "✓ Sudo authenticated"
+# -----------------
 
 # 1. Remove the SDDM theme directory
 echo "Removing SDDM theme from $THEME_DIR..."
@@ -48,4 +62,5 @@ if [[ -d "$TEMPLATE_DIR" ]] && [[ -z "$(ls -A "$TEMPLATE_DIR")" ]]; then
     echo "✓ Removed empty template directory."
 fi
 
+echo ""
 echo "✅ Uninstall complete."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -11,6 +11,7 @@ THEME_NAME="caelestia"
 THEME_DIR="/usr/share/sddm/themes/$THEME_NAME"
 TEMPLATE_FILE="$HOME/.config/caelestia/templates/sddm-theme.conf"
 TEMPLATE_DIR="$HOME/.config/caelestia/templates"
+SERVICE_NAME="caelestia-sync.service"
 
 # --- Sudo check ---
 echo "Caelestia SDDM Theme Uninstaller"
@@ -23,7 +24,31 @@ fi
 echo "✓ Sudo authenticated"
 # -----------------
 
-# 1. Remove the SDDM theme directory
+# 1. Stop and disable the legacy systemd service (for users updating from older versions)
+echo "Checking for legacy systemd service ($SERVICE_NAME)..."
+if systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
+    sudo systemctl stop "$SERVICE_NAME"
+    echo "✓ Stopped service."
+else
+    echo "Service not running, skipped."
+fi
+
+if systemctl is-enabled --quiet "$SERVICE_NAME" 2>/dev/null; then
+    sudo systemctl disable "$SERVICE_NAME"
+    echo "✓ Disabled service."
+else
+    echo "Service not enabled, skipped."
+fi
+
+if [[ -f "/etc/systemd/system/$SERVICE_NAME" ]]; then
+    sudo rm -f "/etc/systemd/system/$SERVICE_NAME"
+    sudo systemctl daemon-reload
+    echo "✓ Removed service file."
+else
+    echo "Service file not found, skipped."
+fi
+
+# 2. Remove the SDDM theme directory
 echo "Removing SDDM theme from $THEME_DIR..."
 if [[ -d "$THEME_DIR" ]]; then
     sudo rm -rf "$THEME_DIR"
@@ -32,7 +57,7 @@ else
     echo "Theme directory not found, skipped."
 fi
 
-# 2. Remove SDDM theme configuration
+# 3. Remove SDDM theme configuration
 echo "Removing SDDM theme configuration..."
 echo "Note: /etc/sddm.conf is left untouched - you may want to manually update Current= setting."
 if [[ -f "/etc/sddm.conf.d/caelestia.conf" ]]; then
@@ -48,7 +73,7 @@ else
     echo "SDDM config drop-in not found, skipped."
 fi
 
-# 3. Remove the template configuration
+# 4. Remove the template configuration
 echo "Removing template file from $TEMPLATE_FILE..."
 if [[ -f "$TEMPLATE_FILE" ]]; then
     rm -f "$TEMPLATE_FILE"


### PR DESCRIPTION
- Prevent running some scripts with sudo directly.
- Make sure proper permissions are set.
- Clean up some stuffs.

Follow up improvements from https://github.com/ItsABigIgloo/caelestia-sddm/pull/31

**And again as side note:**
Anyone who got their caelestia files bricked by root ownership please run:
```bash
./scripts/fix-permissions.sh
```

Also everyone MUST update their posthook command to:
```bash
"wallpaper": {
    "postHook": "sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh --posthook"
}
```