### PR TITLE
fix: harden sync file handling and install permissions

### DIFF
--- a/.github/INSTALLATION.md
+++ b/.github/INSTALLATION.md
@@ -54,7 +54,8 @@ yay -S caelestia-sddm-minimalistv2-git
 
 ## Syncing:
 
-The theme syncs your current wallpaper, avatar, and colors to the SDDM login screen.
+The theme syncs your current wallpaper, avatar, and colors to the SDDM login screen. Only files your user can read normally are synced; missing, unreadable, invalid, or oversized optional files are skipped.
+Readable symlinks, such as an avatar linked from your home directory, are supported.
 
 **Manual Sync:**
 Manually apply changes immediately without rebooting:

--- a/.github/POSTHOOK.md
+++ b/.github/POSTHOOK.md
@@ -38,7 +38,10 @@ Add this line (replace `your_username`):
 your_username ALL=(root) NOPASSWD: /usr/share/sddm/themes/caelestia/scripts/sync.sh
 ```
 
-This grants passwordless sudo only for this sync script.
+This grants passwordless sudo only for this installed sync script. Do not replace this with broader sudo access.
+
+> [!NOTE]
+> sync.sh only installs avatar, wallpaper, and generated theme files that your user can read normally. Missing, unreadable, invalid, or oversized files are skipped.
 
 ## 3) Verify
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -48,9 +48,15 @@ _package_variant() {
   local variant="$1"
   local theme_dir="$pkgdir/usr/share/sddm/themes/caelestia"
   local src_dir="$srcdir/${pkgbase}"
+  local variant_dir="$src_dir/themes/$variant"
+
+  if find "$variant_dir" -type l -print -quit | grep -q .; then
+    echo "Refusing to package theme variant containing symlinks: $variant" >&2
+    exit 1
+  fi
 
   install -dm755 "$theme_dir"
-  cp -r "$src_dir/themes/$variant"/* "$theme_dir/"
+  cp -r "$variant_dir"/* "$theme_dir/"
 
   install -Dm755 "$src_dir/scripts/sync.sh" \
     "$theme_dir/scripts/sync.sh"
@@ -65,6 +71,7 @@ DROPIN
 
   find "$theme_dir/assets" -type d -exec chmod 755 {} + 2>/dev/null || true
   find "$theme_dir/assets" -type f -exec chmod 644 {} + 2>/dev/null || true
+  chmod 755 "$theme_dir/scripts/sync.sh"
   chmod 644 "$theme_dir/theme.conf" 2>/dev/null || true
 }
 

--- a/aur/README-AUR.md
+++ b/aur/README-AUR.md
@@ -24,6 +24,8 @@ sudo pacman -R caelestia-sddm-minimalist-git
 
 The PKGBUILD uses a split-package approach where each theme variant conflicts with others (because they all install to `/usr/share/sddm/themes/caelestia/`).
 
+Theme variants must contain regular files and directories only. Packaging rejects symlinks so the installed SDDM theme tree stays self-contained and predictable.
+
 ### Adding a New Theme
 
 1. **Update `pkgname` array:**

--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -1,21 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This doesnt require sudo, but still has safeguard
+# This script should only be run as the real user.
 if [ "$(id -u)" -eq 0 ]; then
     echo "ERROR: Do not run this script with sudo. Run it normally." >&2
     exit 1
 fi
 
-REAL_USER="${SUDO_USER:-$(whoami)}"
+REAL_USER="$(whoami)"
 REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
 
-for dir in \
-    "$REAL_HOME/.config" \
-    "$REAL_HOME/.local/state/caelestia" \
-    "$REAL_HOME/.local/share/caelestia"; do
+TARGETS=(
+    "$REAL_HOME/.config/caelestia"
+    "$REAL_HOME/.local/state/caelestia"
+    "$REAL_HOME/.local/share/caelestia"
+)
+
+echo "This script requires sudo to fix ownership of Caelestia files."
+sudo -v
+
+for dir in "${TARGETS[@]}"; do
     if [ -d "$dir" ]; then
-        chown -R "$REAL_USER:$REAL_USER" "$dir"
-        echo "✓ Fixed ownership on $dir"
+        sudo chown -hR "$REAL_USER:$REAL_USER" "$dir"
+
+        # Do not follow symlinks while normalizing permissions.
+        find -P "$dir" -xdev -type d -exec chmod u+rwx,go-rwx {} +
+        find -P "$dir" -xdev -type f -exec chmod u+rw,go-rwx {} +
+
+        echo "✓ Fixed ownership and permissions on $dir"
     fi
 done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,7 +92,7 @@ if [ ${#THEMES[@]} -eq 0 ]; then
 fi
 
 echo ""
-read -p "Select theme to install [1-${#THEMES[@]}]: " selection
+read -r -p "Select theme to install [1-${#THEMES[@]}]: " selection
 
 # Validate selection
 if ! [[ "$selection" =~ ^[0-9]+$ ]] || [ "$selection" -lt 1 ] || [ "$selection" -gt ${#THEMES[@]} ]; then
@@ -110,7 +110,12 @@ echo "Installing Caelestia SDDM Theme ($SELECTED_THEME)..."
 sudo mkdir -p "$INSTALL_DIR"
 
 # Copy all files from selected theme
-sudo cp -r "$THEME_SOURCE"/* "$INSTALL_DIR/"
+if find "$THEME_SOURCE" -type l -print -quit | grep -q .; then
+  echo "✗ Unable to install theme due to $THEME_SOURCE containing symlinks." >&2
+  exit 1
+else
+  sudo cp -r "$THEME_SOURCE"/* "$INSTALL_DIR/"
+fi
 
 # Copy universal sync script
 sudo mkdir -p "$INSTALL_DIR/scripts"
@@ -128,15 +133,19 @@ else
   echo "No theme.conf.template found, skipping template creation"
 fi
 
-# 3. Fix permissions so sync.sh have proper root access
-sudo chown -R root:root "$INSTALL_DIR"
-sudo chmod -R 755 "$INSTALL_DIR"
+# 3. Fix permissions so sync.sh has proper root access
+sudo find "$INSTALL_DIR" -type d -exec chmod 755 {} +
+sudo find "$INSTALL_DIR" -type f -exec chmod 644 {} +
+sudo chmod 755 "$INSTALL_DIR/scripts/sync.sh"
+
 if [ -d "$INSTALL_DIR/assets" ]; then
   sudo find "$INSTALL_DIR/assets" -type d -exec chmod 755 {} \;
   sudo find "$INSTALL_DIR/assets" -type f -exec chmod 644 {} \;
 fi
-sudo chmod 644 "$INSTALL_DIR/theme.conf"
-sudo chmod +x "$INSTALL_DIR/scripts/sync.sh"
+
+if [ -f "$INSTALL_DIR/theme.conf" ]; then
+  sudo chmod 644 "$INSTALL_DIR/theme.conf"
+fi
 
 #4. Set the Current theme via drop-in only
 sudo mkdir -p /etc/sddm.conf.d
@@ -168,7 +177,7 @@ EOF
 echo "------------------------------------------------"
 
 # Ask to run post-install checks
-read -p "Run post-install checks? [Y/n]: " run_check
+read -r -p "Run post-install checks? [Y/n]: " run_check
 if [[ -z "$run_check" ]] || [[ "$run_check" =~ ^[Yy]$ ]]; then
   echo ""
   echo "============================================================"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,14 +1,95 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+user_path_exists() {
+    sudo -H -u "$REAL_USER" test -e "$1" || sudo -H -u "$REAL_USER" test -L "$1"
+}
+
+# Ensure we don't copy invalid files,
+# or anything the user shouldn't have access to.
+copy_user_file() {
+    local src="$1"
+    local dest="$2"
+    local max_bytes="$3"
+
+    local dest_dir base read_tmp dest_tmp actual_size
+    dest_dir="$(dirname -- "$dest")"
+    base="$(basename -- "$dest")"
+
+    install -d -o root -g root -m 0755 "$dest_dir"
+
+    read_tmp="$(mktemp)"
+    dest_tmp="$(mktemp "$dest_dir/.${base}.tmp.XXXXXX")"
+
+    fail_cleanup() {
+        rm -f -- "$read_tmp" "$dest_tmp"
+        return 1
+    }
+
+    if ! sudo -H -u "$REAL_USER" test -f "$src" || \
+        ! sudo -H -u "$REAL_USER" test -r "$src"; then
+        fail_cleanup
+        return
+    fi
+
+    if ! sudo -H -u "$REAL_USER" head -c "$((max_bytes + 1))" -- "$src" | cat > "$read_tmp"; then
+        fail_cleanup
+        return
+    fi
+
+    actual_size="$(stat -c '%s' "$read_tmp")"
+
+    if [ "$actual_size" -gt "$max_bytes" ]; then
+        echo "WARNING: Skipping oversized file: $src" >&2
+        fail_cleanup
+        return
+    fi
+
+    if ! install -o root -g root -m 0644 "$read_tmp" "$dest_tmp"; then
+        fail_cleanup
+        return
+    fi
+
+    if ! mv -f -- "$dest_tmp" "$dest"; then
+        fail_cleanup
+        return
+    fi
+
+    rm -f -- "$read_tmp"
+    return 0
+}
+
+sync_optional_user_file() {
+    local src="$1"
+    local dest="$2"
+    local max_bytes="$3"
+    local label="$4"
+
+    if copy_user_file "$src" "$dest" "$max_bytes"; then
+        echo "✓ Synced $label"
+    else
+        rm -f -- "$dest"
+
+        if user_path_exists "$src"; then
+            echo "WARNING: Skipping unreadable or invalid $label: $src" >&2
+        fi
+    fi
+}
+
 # Get the real user and home directory
-if [ -n "$SUDO_USER" ]; then
+if [ -n "${SUDO_USER:-}" ]; then
     REAL_USER="$SUDO_USER"
 else
     echo "ERROR: Cannot determine target user. Try running with sudo." >&2
     exit 1
 fi
+
 REAL_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
+if [ -z "$REAL_HOME" ] || [ "$REAL_HOME" = "/" ]; then
+    echo "ERROR: Could not determine a valid home directory for $REAL_USER." >&2
+    exit 1
+fi
+
 CAEL_STATE="$REAL_HOME/.local/state/caelestia"
 THEME_DIR="/usr/share/sddm/themes/caelestia"
 
@@ -22,9 +103,9 @@ if [ "${1:-}" = "--posthook" ]; then
 elif command -v caelestia &>/dev/null; then
     # IMPORTANT: must use sudo -u here
     mapfile -t SCHEME < <(sudo -H -u "$REAL_USER" caelestia scheme get --name --mode --variant 2>/dev/null)
-    NAME="${SCHEME[0]}"
-    MODE="${SCHEME[1]}"
-    VARIANT="${SCHEME[2]}"
+    NAME="${SCHEME[0]:-}"
+    MODE="${SCHEME[1]:-}"
+    VARIANT="${SCHEME[2]:-}"
     if [ -n "$NAME" ] && [ -n "$MODE" ] && [ -n "$VARIANT" ]; then
         # and here
         sudo -H -u "$REAL_USER" caelestia scheme set --name "$NAME" --mode "$MODE" --variant "$VARIANT" 2>/dev/null
@@ -37,52 +118,52 @@ else
 fi
 
 # 2. Sync avatar files into theme assets so sddm can safely access them without permission issues.
-if [ -f "$REAL_HOME/.face.icon" ]; then
-    cp -f "$REAL_HOME/.face.icon" "$THEME_DIR/assets/avatar.face.icon"
-    chmod 644 "$THEME_DIR/assets/avatar.face.icon"
-    echo "✓ Synced avatar.face.icon"
-else
-    rm -f "$THEME_DIR/assets/avatar.face.icon"
-fi
+sync_optional_user_file \
+    "$REAL_HOME/.face.icon" \
+    "$THEME_DIR/assets/avatar.face.icon" \
+    "$((5 * 1024 * 1024))" \
+    "avatar.face.icon"
 
-if [ -f "$REAL_HOME/.face" ]; then
-    cp -f "$REAL_HOME/.face" "$THEME_DIR/assets/avatar.face"
-    chmod 644 "$THEME_DIR/assets/avatar.face"
-    echo "✓ Synced avatar.face"
-else
-    rm -f "$THEME_DIR/assets/avatar.face"
-fi
+sync_optional_user_file \
+    "$REAL_HOME/.face" \
+    "$THEME_DIR/assets/avatar.face" \
+    "$((5 * 1024 * 1024))" \
+    "avatar.face"
 
 # 3. Sync Colors
-if [ -f "$CAEL_STATE/theme/sddm-theme.conf" ]; then
-    cp -f "$CAEL_STATE/theme/sddm-theme.conf" "$THEME_DIR/theme.conf"
+THEME_CONF_SRC="$CAEL_STATE/theme/sddm-theme.conf"
+THEME_CONF_DEST="$THEME_DIR/theme.conf"
+MAX_THEME_CONF_BYTES=$((1024 * 1024))
 
-    # get system OS name and Hostname
+if copy_user_file "$THEME_CONF_SRC" "$THEME_CONF_DEST" "$MAX_THEME_CONF_BYTES"; then
+    # Get system OS name and Hostname
     sys_os="Linux"
     if [ -f /etc/os-release ]; then
         sys_os=$(grep -oP '^PRETTY_NAME="\K[^"]+' /etc/os-release || grep -oP '^PRETTY_NAME=\K.+' /etc/os-release || echo "Linux")
     fi
     sys_host=$(hostname 2>/dev/null || cat /etc/hostname 2>/dev/null || echo "localhost")
 
-    # update os= and host= in theme.conf if exist
-    sed -i "s/^os=.*/os=$sys_os/" "$THEME_DIR/theme.conf"
-    sed -i "s/^host=.*/host=$sys_host/" "$THEME_DIR/theme.conf"
+    sys_os_escaped=$(printf '%s' "$sys_os" | sed 's/[\/&]/\\&/g')
+    sys_host_escaped=$(printf '%s' "$sys_host" | sed 's/[\/&]/\\&/g')
 
-    chmod 644 "$THEME_DIR/theme.conf"
+    # Update os= and host= in theme.conf if exist
+    sed -i "s/^os=.*/os=$sys_os_escaped/" "$THEME_CONF_DEST"
+    sed -i "s/^host=.*/host=$sys_host_escaped/" "$THEME_CONF_DEST"
+
+    chmod 644 "$THEME_CONF_DEST"
+    echo "✓ Synced theme.conf"
+else
+    echo "No theme.conf found, leaving existing theme.conf unchanged."
 fi
 
 # 4. Sync Wallpaper LAST
-if [[ -f "$CAEL_STATE/wallpaper/current" ]]; then
-    # Detect extension and handle symlinks
-    FILENAME=$(basename "$(readlink -f "$CAEL_STATE/wallpaper/current")")
-    EXT="${FILENAME##*.}"
-    TARGET="background.$EXT"
+WALLPAPER_SRC="$CAEL_STATE/wallpaper/current"
+WALLPAPER_DEST="$THEME_DIR/assets/background"
+MAX_WALLPAPER_BYTES=$((50 * 1024 * 1024))
 
-    # Clean out old backgrounds to prevent collisions
-    rm -f "$THEME_DIR/assets/background."*
-
-    # Copy and set permissions
-    cp -f "$CAEL_STATE/wallpaper/current" "$THEME_DIR/assets/$TARGET"
-    chmod 644 "$THEME_DIR/assets/$TARGET"
-    echo "✓ Synced $TARGET"
+if copy_user_file "$WALLPAPER_SRC" "$WALLPAPER_DEST" "$MAX_WALLPAPER_BYTES"; then
+    rm -f -- "$THEME_DIR/assets/background."*
+    echo "✓ Synced background"
+else
+    echo "No readable wallpaper found, leaving existing background unchanged."
 fi


### PR DESCRIPTION
## Summary

This PR hardens the root-run SDDM sync path while preserving normal theme behavior:

- Reads synced user files as the invoking user before installing them into `/usr/share/sddm/themes/caelestia`
- Preserves utilization of readable symlinked avatars and wallpapers
- Skips unreadable, invalid, or oversized sync inputs
- Avoids making the whole installed theme tree executable
- Scopes permission repair to Caelestia-owned config/state paths
- Rejects symlinks in packaged theme variants so installed package contents stay predictable

## Why this is needed

`scripts/sync.sh` is documented to be used as a Caelestia posthook, with a narrow password-less sudo rule for the installed script.

Before this change, the script copied user-controlled paths as root and then made the copied files world-readable. That meant a user who could run the approved sync command could point a synced path, such as `~/.face.icon`, at a file they could not normally read.

For example:

```sh
ln -sf /etc/shadow ~/.face.icon
sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh --posthook
```

Because the copy happened as root, the target could be copied into the SDDM theme assets and chmod'ed to `0644`, making the copied contents readable afterwards.

While this is a local privilege-boundary issue for the sync flow (run by root as documented) and not something that can be exploited remotely, this still presents as a medium-risk vulnerability.

## What this PR changes

I've kept the model of `scripts/sync.sh` using `SUDO_USER` to identify the invoking user, added safer handling for unset or invalid home directories, and changed the file-copy path so user-controlled sync sources are checked and read as that user instead of being copied directly as root. Only after the source has been successfully read into a temporary file does root install the result into the SDDM theme directory.

This still preserves the ability to use readable symlinks, e.g. for avatars:

```sh
ln -s ~/Pictures/avatar.png ~/.face
sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh
```

But blocks symlinks or paths that the user cannot read normally.

The sync also now applies conservative size limits to avoid copying unexpectedly large files:

- avatars: 5 MiB
- generated `theme.conf`: 1 MiB
- wallpaper/background: 50 MiB

These limits are intended to cover normal avatar images, generated configs, and typical wallpapers while skipping unusually large inputs. This prevents crashing the greeter with oversized files, which could potentially be used as another attack vector.

Missing or invalid avatars remove stale synced avatar files. Missing or invalid `theme.conf` and wallpaper inputs leave the existing theme files in place so a failed sync does not unnecessarily break the login screen.

The installer and AUR packaging changes are made to keep installed files/directories predictable:

- Directory permissions are `0755`
- Regular files permissions are `0644`
- `scripts/sync.sh` remains executable
- Packaged/manual theme variants reject symlinks

`fix-permissions.sh` is also narrowed so it only repairs Caelestia config/state/share paths instead of recursively updating all of `~/.config`.

Documentation for `INSTALLATION.md`, `POSTHOOK.md` and `aur/README-AUR.md` are also updated to clarify the behavior of `sync.sh` and expectations for theme/asset files.

## Validation

Checks passed:

- Readable symlinked user files still sync
- Unreadable symlink targets are blocked
- Code passes `./scripts/dev/lint.sh`
- Script files pass `shellcheck` and `bash -n`
- `makepkg -scf` passes
- `sddm-greeter-qt6` works in test mode

I tested the original upstream behavior and confirmed that a root-only file could be copied through an unreadable symlinked avatar path.

Upstream test output:
https://paste.dxnny.dev/o9Xqg

I then tested this branch and confirmed the same unreadable symlink is skipped and no copied assets are created off normally unreadable files.

Updated test output:
https://paste.dxnny.dev/a9thO

The steps to reproduce this proof-of-concept test can be found below if you wish to run it for yourself.

<details><summary>Reproducible PoC</summary>

This PoC uses an intentionally restricted sudo rule for a throwaway user. It demonstrates the issue in the realistic scenario documented by the package, where a user is allowed to run only `sync.sh` as root for Caelestia-posthook syncing.

## 0. Assumptions

Run setup commands as an admin user with sudo.

This should work on any Linux setup with:

- bash
- sudo
- useradd
- getent
- install
- cp
- chmod

It does not require SDDM to be running.

## 1. Create an underprivileged user

```bash
sudo useradd -m -s /bin/bash caelestia_poc
```

Confirm the user is not in sudo/admin groups:

```bash
id caelestia_poc
```

Expected to not be in any wheel, sudo, or admin-like group.

## 2. Create a root-only file the test user cannot read

```bash
sudo install -d -m 0700 /root/caelestia-poc
echo "root-only secret copied by sync.sh" | sudo tee /root/caelestia-poc/secret.txt >/dev/null
sudo chmod 0600 /root/caelestia-poc/secret.txt
sudo chown root:root /root/caelestia-poc/secret.txt
sudo cat /root/caelestia-poc/secret.txt
```

Verify the test user can't read the file that was just created:

```bash
sudo -u caelestia_poc cat /root/caelestia-poc/secret.txt
```

This should output "Permission denied".

## 3. Install sync.sh into the expected theme path

Fetch the current upstream script into the same path used by the package.

```bash
sudo install -d -m 0755 /usr/share/sddm/themes/caelestia/scripts
sudo install -d -m 0755 /usr/share/sddm/themes/caelestia/assets

sudo curl -fsSL \
  https://raw.githubusercontent.com/ItsABigIgloo/caelestia-sddm/main/scripts/sync.sh \
  -o /usr/share/sddm/themes/caelestia/scripts/sync.sh

sudo chmod 0755 /usr/share/sddm/themes/caelestia/scripts/sync.sh
sudo chown root:root /usr/share/sddm/themes/caelestia/scripts/sync.sh
```

The vulnerable behavior is found in the avatar copy block:

```bash
cp -f "$REAL_HOME/.face.icon" "$THEME_DIR/assets/avatar.face.icon"
chmod 644 "$THEME_DIR/assets/avatar.face.icon"
```

and similarly for `.face`, `theme.conf`, and wallpaper. Currently, these are copied as root and the result is then made readable.

## 4. Add a narrow sudoers rule for only the sync command

```bash
echo 'caelestia_poc ALL=(root) NOPASSWD: /usr/share/sddm/themes/caelestia/scripts/sync.sh' | \
  sudo tee /etc/sudoers.d/caelestia-poc >/dev/null

sudo chmod 0440 /etc/sudoers.d/caelestia-poc
sudo visudo -cf /etc/sudoers.d/caelestia-poc
```

This aligns with the documented posthook setup, which tells users to allow password-less sudo for the sync script.

## 5. Create a user-controlled symlink to the protected file

```bash
sudo -u caelestia_poc ln -sf /root/caelestia-poc/secret.txt /home/caelestia_poc/.face.icon
```

Verify the test user still cannot read through the symlink:

```bash
sudo -u caelestia_poc cat /home/caelestia_poc/.face.icon
```

Again, this should output "Permission denied".

## 6. Run `sync.sh` as the underprivileged user

```bash
sudo -u caelestia_poc sudo /usr/share/sddm/themes/caelestia/scripts/sync.sh --posthook
```

`--posthook` is necessary here to skip color generation, avoiding the script exiting early if no scheme is found (which will happen if done on a fresh install).

The output might include messages about missing Caelestia CLI or state files if this is done on a fresh machine, which is fine. The avatar sync path and "`Synced avatar.face.icon`" is the part to focus on for this PoC.

## 7. Confirm the protected file was copied into a readable location

```bash
ls -l /usr/share/sddm/themes/caelestia/assets/avatar.face.icon
cat /usr/share/sddm/themes/caelestia/assets/avatar.face.icon
```

Expected output:

```
-rw-r--r-- root root ...
root-only secret copied by upstream sync.sh
```

Also confirm our underprivileged test user can now read the copied content with:

```bash
sudo -u caelestia_poc cat /usr/share/sddm/themes/caelestia/assets/avatar.face.icon
```

The output should include:
`root-only secret copied by upstream sync.sh`

That demonstrates the user could not read /root/caelestia-poc/secret.txt, but after invoking the allowed root-run sync script, the content became readable through the copied theme asset. This demonstration can also be performed with `.face`, `wallpaper/current`, and any other user-input file.

## 8. Cleanup

If this was ran on a personal machine and you wish to cleanup the files from the test:

```bash
sudo rm -f /etc/sudoers.d/caelestia-poc
sudo rm -rf /root/caelestia-poc
sudo userdel -r caelestia_poc
```

Don't run this fully if you want to preserve your theme files. Just replace ~/.face.icon with your actual avatar and re-run the posthook script.

```bash
sudo rm -rf /usr/share/sddm/themes/caelestia
```

</details>