### PR TITLE
fix: morph-Binding-Loop-Fix (CPU) (kinda critical)

### DIFF
--- a/themes/locklike/components/Avatar.qml
+++ b/themes/locklike/components/Avatar.qml
@@ -4,17 +4,28 @@ import "shapes"
 import "shapes/material-shapes.js" as MaterialShapes
 
 Item {
-    id: root
+    // --- Mask sources for OpacityMask ---
+    // --- Profile picture ---
 
-    z: 2
+    id: root
 
     /// Avatar shape: "hexagon" (Material Design blob) or "circle"
     property string avatarShape: "hexagon"
-
     // Hexagon mode properties
     property bool hovered: false
     property int hexIndex: 0
     property var shapeGetters: [MaterialShapes.getClamShell, MaterialShapes.getCookie6Sided]
+
+    z: 2
+    onHoveredChanged: {
+        if (root.avatarShape !== "hexagon")
+            return ;
+
+        if (hovered)
+            root.hexIndex = 1;
+        else
+            root.hexIndex = 0;
+    }
 
     // Hover interaction (switches hexagon shape on hover; no-op in circle mode)
     MouseArea {
@@ -24,21 +35,10 @@ Item {
         onExited: hovered = false
     }
 
-    onHoveredChanged: {
-        if (root.avatarShape !== "hexagon")
-            return;
-        if (hovered) {
-            root.hexIndex = 1;
-        } else {
-            root.hexIndex = 0;
-        }
-    }
-
-    // --- Mask sources for OpacityMask ---
-
     // Hexagon shape (used as mask in hexagon mode)
     ShapeCanvas {
         id: hexMask
+
         anchors.fill: parent
         visible: root.avatarShape === "hexagon"
         roundedPolygon: root.shapeGetters[root.hexIndex]()
@@ -49,13 +49,12 @@ Item {
     // Circular mask (used as mask in circle mode)
     Rectangle {
         id: circleMask
+
         anchors.fill: parent
         visible: root.avatarShape === "circle"
         radius: Math.min(width, height) / 2
         color: "#000000"
     }
-
-    // --- Profile picture ---
 
     Image {
         id: avatarImage
@@ -79,6 +78,7 @@ Item {
         onStatusChanged: {
             if (status === Image.Error)
                 retryTimer.start();
+
         }
         Component.onCompleted: loadNextAvatar()
 
@@ -92,5 +92,7 @@ Item {
         layer.effect: OpacityMask {
             maskSource: root.avatarShape === "circle" ? circleMask : hexMask
         }
+
     }
+
 }

--- a/themes/locklike/components/LayerState.qml
+++ b/themes/locklike/components/LayerState.qml
@@ -1,5 +1,5 @@
-import QtQuick
 import Qt5Compat.GraphicalEffects
+import QtQuick
 
 Item {
     id: root
@@ -15,7 +15,7 @@ Item {
     property real parentHeight
     property real parentRadius
 
-    signal clicked
+    signal clicked()
 
     anchors.fill: parent
     layer.enabled: true
@@ -27,7 +27,7 @@ Item {
         hoverEnabled: true
         enabled: !root.disabled
         cursorShape: Qt.PointingHandCursor
-        onPressed: event => {
+        onPressed: (event) => {
             ripple.x = event.x;
             ripple.y = event.y;
             const dist = (ox, oy) => {
@@ -50,11 +50,14 @@ Item {
         bottomLeftRadius: root.bottomLeftradius
         bottomRightRadius: root.bottomRightradius
         color: mouse.pressed ? Qt.rgba(root.rippleColor.r, root.rippleColor.g, root.rippleColor.b, 0.2) : mouse.containsMouse ? Qt.rgba(root.rippleColor.r, root.rippleColor.g, root.rippleColor.b, 0.15) : "transparent"
+
         Behavior on color {
             ColorAnimation {
                 duration: 160
             }
+
         }
+
     }
 
     Rectangle {
@@ -68,6 +71,7 @@ Item {
             x: -ripple.width / 2
             y: -ripple.height / 2
         }
+
     }
 
     NumberAnimation {
@@ -88,7 +92,9 @@ Item {
         to: 0
         duration: 200
     }
+
     layer.effect: OpacityMask {
+
         maskSource: Rectangle {
             width: parentWidth
             height: parentHeight
@@ -97,5 +103,7 @@ Item {
             bottomLeftRadius: root.bottomLeftradius
             bottomRightRadius: root.bottomRightradius
         }
+
     }
+
 }

--- a/themes/locklike/components/Logo.qml
+++ b/themes/locklike/components/Logo.qml
@@ -20,7 +20,7 @@ Item {
     readonly property alias star2: star2
     readonly property alias star3: star3
 
-    signal animationCompleted
+    signal animationCompleted()
 
     implicitWidth: 128
     implicitHeight: 90.38
@@ -78,7 +78,9 @@ Item {
                 PathSvg {
                     path: "m42.56,42.96c-7.76,1.6-16.36,4.22-22.44,6.22-.49.16-.88-.44-.53-.82,5.37-5.85,9.66-13.3,9.66-13.3,8.66-14.67,22.97-23.51,39.85-21.14,6.47.91,12.33,3.38,17.26,6.98.99.72,1.14,2.14.31,3.04-.4.44-.95.67-1.51.67-.34,0-.69-.09-1-.26-3.21-1.84-6.82-2.69-10.71-3.24-13.1-1.84-25.41,4.75-31.06,15.83-.94,1.84-.61,3.81.45,5.21.22.3.07.72-.29.8Z"
                 }
+
             }
+
         }
 
         Shape {
@@ -94,7 +96,9 @@ Item {
                 PathSvg {
                     path: "m103.02,51.8c-.65.11-1.26-.37-1.28-1.03-.06-1.96.15-3.89-.2-5.78-.28-1.48-1.66-2.5-3.16-2.34h-.05c-6.53.73-24.63,3.1-48,9.32-6.89,1.83-9.83,10-5.67,15.79,4.62,6.44,11.84,10.93,20.41,12.13,11.82,1.66,22.99-3.36,29.21-12.65.54-.81,1.54-1.17,2.47-.86.91.3,1.47,1.15,1.47,2.04,0,.33-.08.66-.24.98-7.23,14.21-22.91,22.95-39.59,20.6-7.84-1.1-14.8-4.5-20.28-9.43,0,0,0,0-.02-.01-7.28-5.14-14.7-9.99-27.24-11.98-18.82-2.98-9.53-8.75.46-13.78,7.36-3.13,25.17-7.9,36.24-10.73.16-.03.31-.06.47-.1,1.52-.4,3.2-.83,5.02-1.29,1.06-.26,1.93-.48,2.58-.64.09-.02.18-.04.26-.06.31-.08.56-.14.73-.18.03,0,.06-.01.08-.02.03,0,.05-.01.07-.02.02,0,.04,0,.06-.01.01,0,.03,0,.04-.01,0,0,.02,0,.03,0,.01,0,.02,0,.02,0,10.62-2.58,24.63-5.62,37.74-7.34,1.02-.13,2.03-.26,3.03-.37,7.49-.87,14.58-1.26,20.42-.81,25.43,1.95-4.71,16.77-15.12,18.61Z"
                 }
+
             }
+
         }
 
         Shape {
@@ -111,7 +115,9 @@ Item {
                 PathSvg {
                     path: "m98.12.06c-.29,2.08-1.72,8.42-8.36,9.19-.09,0-.09.13,0,.14,6.64.78,8.07,7.11,8.36,9.19.01.08.13.08.14,0,.29-2.08,1.72-8.42,8.36-9.19.09,0,.09-.13,0-.14-6.64-.78-8.07-7.11-8.36-9.19-.01-.08-.13-.08-.14,0Z"
                 }
+
             }
+
         }
 
         Shape {
@@ -128,7 +134,9 @@ Item {
                 PathSvg {
                     path: "m113.36,15.5c-.22,1.29-1.08,4.35-4.38,4.87-.08.01-.08.13,0,.14,3.3.52,4.17,3.58,4.38,4.87.01.08.13.08.14,0,.22-1.29,1.08-4.35,4.38-4.87.08-.01.08-.13,0-.14-3.3-.52-4.17-3.58-4.38-4.87-.01-.08-.13-.08-.14,0Z"
                 }
+
             }
+
         }
 
         Shape {
@@ -145,7 +153,9 @@ Item {
                 PathSvg {
                     path: "m112.69,65.22c-.19,1.01-.86,3.15-3.2,3.57-.08.01-.08.13,0,.14,2.34.42,3.01,2.56,3.2,3.57.01.08.13.08.14,0,.19-1.01.86-3.15,3.2-3.57.08-.01.08-.13,0-.14-2.34-.42-3.01-2.56-3.2-3.57-.01-.08-.13-.08-.14,0Z"
                 }
+
             }
+
         }
 
         layer.effect: MultiEffect {
@@ -153,6 +163,7 @@ Item {
             blur: root.blurAmount
             blurMax: 60
         }
+
     }
 
     SequentialAnimation {
@@ -206,6 +217,7 @@ Item {
                 ScriptAction {
                     script: logo.rotation = 0
                 }
+
             }
 
             SequentialAnimation {
@@ -236,6 +248,7 @@ Item {
                     easing.type: Easing.OutBack
                     easing.overshoot: 1.05
                 }
+
             }
 
             NumberAnimation {
@@ -289,8 +302,11 @@ Item {
                             duration: 400 * speedFactor
                             easing.type: Easing.InOutQuad
                         }
+
                     }
+
                 }
+
             }
 
             SequentialAnimation {
@@ -326,8 +342,11 @@ Item {
                             duration: 400 * speedFactor
                             easing.type: Easing.InOutQuad
                         }
+
                     }
+
                 }
+
             }
 
             SequentialAnimation {
@@ -363,10 +382,15 @@ Item {
                             duration: 400 * speedFactor
                             easing.type: Easing.InOutQuad
                         }
+
                     }
+
                 }
+
             }
+
         }
+
     }
 
     SequentialAnimation {
@@ -398,6 +422,7 @@ Item {
                     duration: 2500 * speedFactor
                     easing.type: Easing.InOutQuad
                 }
+
             }
 
             SequentialAnimation {
@@ -420,6 +445,7 @@ Item {
                     duration: 3000 * speedFactor
                     easing.type: Easing.InOutQuad
                 }
+
             }
 
             SequentialAnimation {
@@ -442,6 +468,7 @@ Item {
                     duration: 2800 * speedFactor
                     easing.type: Easing.InOutQuad
                 }
+
             }
 
             SequentialAnimation {
@@ -464,6 +491,7 @@ Item {
                     duration: 2500 * speedFactor
                     easing.type: Easing.InOutQuad
                 }
+
             }
 
             SequentialAnimation {
@@ -486,6 +514,7 @@ Item {
                     duration: 3000 * speedFactor
                     easing.type: Easing.InOutQuad
                 }
+
             }
 
             SequentialAnimation {
@@ -508,7 +537,11 @@ Item {
                     duration: 2800 * speedFactor
                     easing.type: Easing.InOutQuad
                 }
+
             }
+
         }
+
     }
+
 }

--- a/themes/locklike/components/MainClock.qml
+++ b/themes/locklike/components/MainClock.qml
@@ -6,22 +6,20 @@ Item {
     property bool firstInput
     property real mainCardComponentsOpacity
     property bool ap
-
     property real centerScale: 1
     property date currentTime: new Date()
-
     readonly property var fontAxesHours: ({
-            "wght": 500,
-            "wdth": 30,
-            "ROND": 25,
-            "opsz": 224 * centerScale
-        })
+        "wght": 500,
+        "wdth": 30,
+        "ROND": 25,
+        "opsz": 224 * centerScale
+    })
     readonly property var fontAxesMinutes: ({
-            "wght": 500,
-            "wdth": 30,
-            "ROND": 25,
-            "opsz": 224 * centerScale
-        })
+        "wght": 500,
+        "wdth": 30,
+        "ROND": 25,
+        "opsz": 224 * centerScale
+    })
 
     FontLoader {
         id: googleSansFlex
@@ -31,6 +29,7 @@ Item {
 
     Row {
         id: clock
+
         anchors.centerIn: parent
 
         Text {
@@ -59,6 +58,7 @@ Item {
             color: config.secondary
             text: Qt.formatTime(root.currentTime, "mm")
         }
+
     }
 
     Behavior on opacity {
@@ -66,5 +66,7 @@ Item {
             duration: 300
             easing.type: Easing.OutBack
         }
+
     }
+
 }

--- a/themes/locklike/components/PasswordInput.qml
+++ b/themes/locklike/components/PasswordInput.qml
@@ -7,38 +7,35 @@ import "shapes/shapes/morph.js" as Morph
 
 Rectangle {
     id: passwordRoot
-    color: "transparent"
 
     property alias currentSession: inputRect.currentSession
     property alias currentUser: inputRect.currentUser
     property alias buffer: inputRect.buffer
-
-    onBufferChanged: {
-        while (dotModel.count < buffer.length)
-            dotModel.append({
-                shapeIdx: Math.floor(Math.random() * 5)
-            });
-        while (dotModel.count > buffer.length)
-            dotModel.remove(dotModel.count - 1);
-    }
-
-    ListModel {
-        id: dotModel
-    }
+    property alias isLoading: inputRect.isLoading
+    property alias firstInput: inputRect.firstInput
+    property alias mainCardComponentsOpacity: inputRect.mainCardComponentsOpacity
 
     function dotPath(morph, progress, size) {
         const cubics = morph.asCubics(progress);
         if (!cubics || cubics.length === 0)
             return "";
+
         let d = "M " + (cubics[0].anchor0X * size) + " " + (cubics[0].anchor0Y * size);
-        for (const c of cubics)
-            d += " C " + (c.control0X * size) + " " + (c.control0Y * size) + " " + (c.control1X * size) + " " + (c.control1Y * size) + " " + (c.anchor1X * size) + " " + (c.anchor1Y * size);
+        for (const c of cubics) d += " C " + (c.control0X * size) + " " + (c.control0Y * size) + " " + (c.control1X * size) + " " + (c.control1Y * size) + " " + (c.anchor1X * size) + " " + (c.anchor1Y * size)
         return d + " Z";
     }
 
-    property alias isLoading: inputRect.isLoading
-    property alias firstInput: inputRect.firstInput
-    property alias mainCardComponentsOpacity: inputRect.mainCardComponentsOpacity
+    color: "transparent"
+    onBufferChanged: {
+        while (dotModel.count < buffer.length)dotModel.append({
+            "shapeIdx": Math.floor(Math.random() * 5)
+        })
+        while (dotModel.count > buffer.length)dotModel.remove(dotModel.count - 1)
+    }
+
+    ListModel {
+        id: dotModel
+    }
 
     Rectangle {
         id: inputRect
@@ -49,33 +46,26 @@ Rectangle {
         property string buffer
         property string currentUser
         property int currentSession
-        anchors.horizontalCenter: parent.horizontalCenter
 
-        onIsLoadingChanged: {
-            if (!inputRect.isLoading) {
-                inputRect.width = 365;
-            }
+        function shake() {
+            shakeRotation.start();
         }
 
+        anchors.horizontalCenter: parent.horizontalCenter
+        onIsLoadingChanged: {
+            if (!inputRect.isLoading)
+                inputRect.width = 365;
+
+        }
         color: config.subComponents
         radius: 30
         width: inputRect.buffer === "" ? 300 : 365
         height: 45
         opacity: inputRect.firstInput ? 0 : inputRect.mainCardComponentsOpacity
 
-        Behavior on width {
-            NumberAnimation {
-                duration: 300
-                easing.type: Easing.OutBack
-            }
-        }
-
-        function shake() {
-            shakeRotation.start();
-        }
-
         Text {
             id: lockIcon
+
             renderType: Text.NativeRendering
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
@@ -89,15 +79,15 @@ Rectangle {
 
         ShapeCanvas {
             id: loadingShape
+
             property int index: 0
             property var shapeGetters: [MaterialShapes.getGem, MaterialShapes.getSunny, MaterialShapes.getCookie4Sided, MaterialShapes.getCookie6Sided, MaterialShapes.getVerySunny]
+
             opacity: inputRect.isLoading ? 1 : 0
             color: config.secondary
-
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: 17
-
             implicitWidth: lockIcon.height / 2 * 2.1
             implicitHeight: lockIcon.height / 2 * 2.1
             roundedPolygon: loadingShape.shapeGetters[loadingShape.index]()
@@ -106,11 +96,10 @@ Rectangle {
                 running: inputRect.isLoading
                 interval: 500
                 onTriggered: {
-                    if (loadingShape.index == 4) {
+                    if (loadingShape.index == 4)
                         loadingShape.index = 0;
-                    } else {
+                    else
                         loadingShape.index = loadingShape.index + 1;
-                    }
                     scaleAnim.running = true;
                 }
                 repeat: true
@@ -120,7 +109,9 @@ Rectangle {
                 NumberAnimation {
                     duration: 400
                 }
+
             }
+
         }
 
         SequentialAnimation {
@@ -134,12 +125,14 @@ Rectangle {
                 to: 1.2
                 duration: 100
             }
+
             NumberAnimation {
                 target: loadingShape
                 property: "scale"
                 to: 1
                 duration: 100
             }
+
         }
 
         SequentialAnimation {
@@ -195,6 +188,7 @@ Rectangle {
                 to: 0
                 duration: 50
             }
+
         }
 
         SequentialAnimation {
@@ -209,6 +203,7 @@ Rectangle {
                 duration: 300
                 easing.type: Easing.OutBack
             }
+
         }
 
         Rectangle {
@@ -234,7 +229,9 @@ Rectangle {
                     NumberAnimation {
                         duration: 100
                     }
+
                 }
+
             }
 
             ListView {
@@ -243,11 +240,9 @@ Rectangle {
                 orientation: ListView.Horizontal
                 spacing: 3
                 interactive: false
-
                 width: inputRect.buffer.length * 15 + (inputRect.buffer.length - 1) * 3 + parent.height
                 height: 15
                 anchors.centerIn: parent
-
                 model: dotModel
 
                 Behavior on width {
@@ -255,21 +250,25 @@ Rectangle {
                         duration: 150
                         easing: Easing.OutCubic
                     }
+
                 }
 
                 delegate: Item {
                     id: dot
 
                     required property int shapeIdx
+                    property var shapeGetters: [MaterialShapes.getGem, MaterialShapes.getSunny, MaterialShapes.getCookie4Sided, MaterialShapes.getVerySunny, MaterialShapes.getCookie6Sided]
+                    property var morph: new Morph.Morph(shapeGetters[shapeIdx](), MaterialShapes.getCircle())
+                    property real morphProgress: 0
 
                     width: 15
                     height: 15
                     scale: 0
                     opacity: 0
-
-                    property var shapeGetters: [MaterialShapes.getGem, MaterialShapes.getSunny, MaterialShapes.getCookie4Sided, MaterialShapes.getVerySunny, MaterialShapes.getCookie6Sided]
-                    property var morph: new Morph.Morph(shapeGetters[shapeIdx](), MaterialShapes.getCircle())
-                    property real morphProgress: 0
+                    ListView.onRemove: {
+                        initAnim.stop();
+                        removeAnim.start();
+                    }
 
                     Shape {
                         anchors.fill: parent
@@ -283,11 +282,14 @@ Rectangle {
                             PathSvg {
                                 path: passwordRoot.dotPath(dot.morph, dot.morphProgress, Math.min(dot.width, dot.height))
                             }
+
                         }
+
                     }
 
                     SequentialAnimation {
                         id: initAnim
+
                         running: true
 
                         ParallelAnimation {
@@ -298,6 +300,7 @@ Rectangle {
                                 to: 1
                                 duration: 150
                             }
+
                             SequentialAnimation {
                                 NumberAnimation {
                                     target: dot
@@ -307,17 +310,22 @@ Rectangle {
                                     duration: 180
                                     easing.type: Easing.OutCubic
                                 }
+
                                 NumberAnimation {
                                     target: dot
                                     property: "scale"
                                     to: 1
                                     duration: 150
                                 }
+
                             }
+
                         }
+
                         PauseAnimation {
                             duration: 180
                         }
+
                         NumberAnimation {
                             target: dot
                             property: "morphProgress"
@@ -326,11 +334,7 @@ Rectangle {
                             duration: 350
                             easing.type: Easing.OutCubic
                         }
-                    }
 
-                    ListView.onRemove: {
-                        initAnim.stop();
-                        removeAnim.start();
                     }
 
                     SequentialAnimation {
@@ -341,6 +345,7 @@ Rectangle {
                             property: "ListView.delayRemove"
                             value: true
                         }
+
                         ParallelAnimation {
                             NumberAnimation {
                                 target: dot
@@ -348,6 +353,7 @@ Rectangle {
                                 to: 0
                                 duration: 150
                             }
+
                             NumberAnimation {
                                 target: dot
                                 property: "scale"
@@ -355,19 +361,27 @@ Rectangle {
                                 duration: 150
                                 easing.type: Easing.InCubic
                             }
+
                         }
+
                         PropertyAction {
                             target: dot
                             property: "ListView.delayRemove"
                             value: false
                         }
+
                     }
+
                 }
+
             }
+
         }
 
         Rectangle {
             id: inputButtonShape
+
+            property var shapeGetters: [MaterialShapes.getCircle, MaterialShapes.getArrow]
 
             radius: 48
             width: inputRect.height - 7
@@ -377,10 +391,9 @@ Rectangle {
             anchors.rightMargin: 4
             color: "transparent"
 
-            property var shapeGetters: [MaterialShapes.getCircle, MaterialShapes.getArrow]
-
             ShapeCanvas {
                 id: shape
+
                 rotation: 90
                 scale: inputRect.buffer === "" ? 0.9 : 0.7
                 implicitWidth: inputButtonShape.height / 2 * 2.1
@@ -398,26 +411,15 @@ Rectangle {
                     text: "\ue941"
                     color: config.text
                     opacity: inputRect.buffer === "" ? 1 : 0
+
                     Behavior on opacity {
                         NumberAnimation {
                             duration: 200
                             easing.type: Easing.OutCubic
                         }
-                    }
-                }
 
-                Behavior on color {
-                    ColorAnimation {
-                        duration: 200
-                        easing.type: Easing.OutCubic
                     }
-                }
 
-                Behavior on scale {
-                    NumberAnimation {
-                        duration: 200
-                        easing.type: Easing.OutCubic
-                    }
                 }
 
                 MouseArea {
@@ -435,7 +437,33 @@ Rectangle {
                         inputRect.buffer = "";
                     }
                 }
+
+                Behavior on color {
+                    ColorAnimation {
+                        duration: 200
+                        easing.type: Easing.OutCubic
+                    }
+
+                }
+
+                Behavior on scale {
+                    NumberAnimation {
+                        duration: 200
+                        easing.type: Easing.OutCubic
+                    }
+
+                }
+
             }
+
+        }
+
+        Behavior on width {
+            NumberAnimation {
+                duration: 300
+                easing.type: Easing.OutBack
+            }
+
         }
 
         Behavior on opacity {
@@ -443,6 +471,9 @@ Rectangle {
                 duration: 300
                 easing.type: Easing.OutBack
             }
+
         }
+
     }
+
 }

--- a/themes/locklike/components/SessionPicker.qml
+++ b/themes/locklike/components/SessionPicker.qml
@@ -9,6 +9,7 @@ Item {
     property var items: []
     property int selectedIndex: 0
     property string currentText
+
     Component.onCompleted: {
         root.currentText = sessionArray.sessions[root.selectedIndex].name;
         var arr = [];
@@ -20,7 +21,6 @@ Item {
     onSelectedIndexChanged: {
         root.currentText = sessionArray.sessions[root.selectedIndex].name;
     }
-
     width: labelRect.width + expandBtn.width
     height: 40
     opacity: root.count > 0 ? 1 : 0
@@ -28,17 +28,20 @@ Item {
 
     Instantiator {
         id: sessionArray
-        model: sessionModel
+
         property var sessions: []
+
+        model: sessionModel
 
         delegate: Item {
             Component.onCompleted: {
                 sessionArray.sessions.push({
-                    index: index,
-                    name: model.name
+                    "index": index,
+                    "name": model.name
                 });
             }
         }
+
     }
 
     Rectangle {
@@ -53,7 +56,6 @@ Item {
         topRightRadius: 5
         bottomRightRadius: 5
         color: config.subComponents
-
         width: 210
 
         Row {
@@ -82,6 +84,7 @@ Item {
                 font.family: "Rubik"
                 elide: Text.ElideRight
             }
+
         }
 
         LayerState {
@@ -93,6 +96,7 @@ Item {
             topRightradius: labelRect.topRightRadius
             bottomRightradius: labelRect.bottomRightRadius
         }
+
     }
 
     Rectangle {
@@ -107,22 +111,7 @@ Item {
         topLeftRadius: rad
         bottomLeftRadius: rad
         color: config.primary
-
         width: height
-
-        Behavior on topLeftRadius {
-            NumberAnimation {
-                duration: 200
-                easing.type: Easing.InOutCubic
-            }
-        }
-
-        Behavior on bottomLeftRadius {
-            NumberAnimation {
-                duration: 200
-                easing.type: Easing.InOutCubic
-            }
-        }
 
         Text {
             id: expandIcon
@@ -140,6 +129,7 @@ Item {
                     duration: 200
                     easing.type: Easing.InOutCubic
                 }
+
             }
 
             Behavior on rotation {
@@ -147,7 +137,9 @@ Item {
                     duration: 200
                     easing.type: Easing.InOutCubic
                 }
+
             }
+
         }
 
         LayerState {
@@ -157,6 +149,23 @@ Item {
             parentRadius: expandBtn.radius
             onClicked: root.expanded = !root.expanded
         }
+
+        Behavior on topLeftRadius {
+            NumberAnimation {
+                duration: 200
+                easing.type: Easing.InOutCubic
+            }
+
+        }
+
+        Behavior on bottomLeftRadius {
+            NumberAnimation {
+                duration: 200
+                easing.type: Easing.InOutCubic
+            }
+
+        }
+
     }
 
     Rectangle {
@@ -167,34 +176,14 @@ Item {
         radius: 8
         border.color: config.outline
         border.width: 1
-
         anchors.top: labelRect.bottom
         anchors.topMargin: 4
         anchors.left: labelRect.left
         anchors.leftMargin: -10
         width: 260
         height: Math.min(200, root.count * 36)
-
         clip: true
-
         opacity: root.expanded ? 1 : 0
-        transform: Translate {
-            y: root.expanded ? 0 : -10
-        }
-
-        Behavior on opacity {
-            NumberAnimation {
-                duration: 150
-                easing.type: Easing.InOutCubic
-            }
-        }
-
-        Behavior on y {
-            NumberAnimation {
-                duration: 150
-                easing.type: Easing.InOutCubic
-            }
-        }
 
         ListView {
             id: sessionList
@@ -214,12 +203,6 @@ Item {
                 radius: 4
                 color: index === ListView.view.currentIndex ? config.primary : "transparent"
                 opacity: index === ListView.view.currentIndex ? 0.2 : 1
-
-                Behavior on color {
-                    ColorAnimation {
-                        duration: 100
-                    }
-                }
 
                 MouseArea {
                     anchors.fill: parent
@@ -241,8 +224,38 @@ Item {
                     leftPadding: 4
                     rightPadding: 4
                 }
+
+                Behavior on color {
+                    ColorAnimation {
+                        duration: 100
+                    }
+
+                }
+
             }
+
         }
+
+        transform: Translate {
+            y: root.expanded ? 0 : -10
+        }
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 150
+                easing.type: Easing.InOutCubic
+            }
+
+        }
+
+        Behavior on y {
+            NumberAnimation {
+                duration: 150
+                easing.type: Easing.InOutCubic
+            }
+
+        }
+
     }
 
     MouseArea {
@@ -253,4 +266,5 @@ Item {
         enabled: root.expanded
         onClicked: root.expanded = false
     }
+
 }

--- a/themes/locklike/components/shapes/ShapeCanvas.qml
+++ b/themes/locklike/components/shapes/ShapeCanvas.qml
@@ -20,7 +20,7 @@ Canvas {
     // Internals: anim
     property var prevRoundedPolygon: null
     property double progress: 1
-    property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)
+    property var morph: null
     property Animation animation: NumberAnimation {
         duration: 350
         easing.type: Easing.BezierSpline

--- a/themes/locklike/components/shapes/ShapeCanvas.qml
+++ b/themes/locklike/components/shapes/ShapeCanvas.qml
@@ -3,6 +3,7 @@ import "shapes/morph.js" as Morph
 
 Canvas {
     id: root
+
     property color color: "#685496"
     property var roundedPolygon: null
     property bool polygonIsNormalized: true
@@ -11,22 +12,22 @@ Canvas {
     property bool debug: false
     property real xOffset: 0
     property real yOffset: 0
-
     // Internals: size
     property var bounds: roundedPolygon.calculateBounds()
-    implicitWidth: bounds[2] - bounds[0]
-    implicitHeight: bounds[3] - bounds[1]
-
     // Internals: anim
     property var prevRoundedPolygon: null
     property double progress: 1
     property var morph: null
-    property Animation animation: NumberAnimation {
+    property Animation animation
+
+    animation: NumberAnimation {
         duration: 350
         easing.type: Easing.BezierSpline
-        easing.bezierCurve: [0.42, 1.67, 0.21, 0.90, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
+        easing.bezierCurve: [0.42, 1.67, 0.21, 0.9, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
     }
 
+    implicitWidth: bounds[2] - bounds[0]
+    implicitHeight: bounds[3] - bounds[1]
     onRoundedPolygonChanged: {
         delete root.morph;
         root.morph = new Morph.Morph(root.prevRoundedPolygon ?? root.roundedPolygon, root.roundedPolygon);
@@ -36,12 +37,6 @@ Canvas {
         root.progress = 1;
         root.prevRoundedPolygon = root.roundedPolygon;
     }
-
-    Behavior on progress {
-        id: morphBehavior
-        animation: root.animation
-    }
-
     onProgressChanged: requestPaint()
     onColorChanged: requestPaint()
     onBorderWidthChanged: requestPaint()
@@ -49,24 +44,23 @@ Canvas {
     onDebugChanged: requestPaint()
     onXOffsetChanged: requestPaint()
     onYOffsetChanged: requestPaint()
-
     onPaint: {
         var ctx = getContext("2d");
         ctx.fillStyle = root.color;
         ctx.clearRect(0, 0, width, height);
         if (!root.morph)
-            return;
+            return ;
+
         const cubics = root.morph.asCubics(root.progress);
         if (cubics.length === 0)
-            return;
+            return ;
+
         const size = Math.min(root.width, root.height);
-
         ctx.save();
-        if (root.polygonIsNormalized) {
+        if (root.polygonIsNormalized)
             ctx.scale(size, size);
-        }
-        ctx.translate(root.xOffset, root.yOffset);
 
+        ctx.translate(root.xOffset, root.yOffset);
         ctx.beginPath();
         ctx.moveTo(cubics[0].anchor0X, cubics[0].anchor0Y);
         for (const cubic of cubics) {
@@ -74,30 +68,27 @@ Canvas {
         }
         ctx.closePath();
         ctx.fill();
-
         if (root.borderWidth > 0) {
             ctx.strokeStyle = root.borderColor;
             ctx.lineWidth = root.borderWidth;
             ctx.stroke();
         }
-
         if (root.debug) {
             const points = [];
             for (let i = 0; i < cubics.length; ++i) {
                 const c = cubics[i];
                 if (i === 0)
                     points.push({
-                        x: c.anchor0X,
-                        y: c.anchor0Y
-                    });
+                    "x": c.anchor0X,
+                    "y": c.anchor0Y
+                });
+
                 points.push({
-                    x: c.anchor1X,
-                    y: c.anchor1Y
+                    "x": c.anchor1X,
+                    "y": c.anchor1Y
                 });
             }
-
             let radius = 2;
-
             ctx.fillStyle = "red";
             for (const p of points) {
                 ctx.beginPath();
@@ -105,7 +96,13 @@ Canvas {
                 ctx.fill();
             }
         }
-
         ctx.restore();
     }
+
+    Behavior on progress {
+        id: morphBehavior
+
+        animation: root.animation
+    }
+
 }

--- a/themes/locklike/widgets/CaelestiaFetch.qml
+++ b/themes/locklike/widgets/CaelestiaFetch.qml
@@ -9,8 +9,6 @@ Item {
     required property string currentSession
     required property string currentUser
     required property int rectHeight
-
-
     property string os: (config.os || "Arch").split(" ")[0]
     property string host: config.host || "localhost"
     property string session: (root.currentSession || "Hyprland").split(" ")[0]
@@ -33,6 +31,7 @@ Item {
                 font.family: "CaskaydiaCove NF"
                 font.pointSize: 15
             }
+
         }
 
         Text {
@@ -45,6 +44,7 @@ Item {
             Layout.topMargin: 32
             Layout.leftMargin: 8
         }
+
     }
 
     ColumnLayout {
@@ -94,7 +94,9 @@ Item {
                     lineHeightMode: Text.FixedHeight
                     Layout.preferredWidth: 100
                 }
+
             }
+
         }
 
         RowLayout {
@@ -151,6 +153,9 @@ Item {
                 color: config.inverseOnSurface
                 radius: 12
             }
+
         }
+
     }
+
 }

--- a/themes/locklike/widgets/SystemButtons.qml
+++ b/themes/locklike/widgets/SystemButtons.qml
@@ -48,7 +48,9 @@ Item {
             ColorAnimation {
                 duration: 200
             }
+
         }
+
     }
 
     Rectangle {
@@ -88,6 +90,9 @@ Item {
             ColorAnimation {
                 duration: 200
             }
+
         }
+
     }
+
 }

--- a/themes/locklike/widgets/WelcomeText.qml
+++ b/themes/locklike/widgets/WelcomeText.qml
@@ -38,4 +38,5 @@ Item {
         onTriggered: topLeftRect.getPhase()
         repeat: true
     }
+
 }

--- a/themes/minimalist/Main.qml
+++ b/themes/minimalist/Main.qml
@@ -50,6 +50,7 @@ Rectangle {
             if (event.key === Qt.Key_Escape) {
                 if (Theme.enableWelcomeMessage)
                     root.firstInput = true;
+
                 clearBuffer();
                 return ;
             }

--- a/themes/minimalist/singletons/Theme.qml
+++ b/themes/minimalist/singletons/Theme.qml
@@ -50,6 +50,7 @@ QtObject {
         var val = getConfig("welcomeMessage");
         if (val === undefined)
             return "Welcome $USER";
+
         return val.toString().replace(/^"|"$/g, "");
     }
     // effects

--- a/themes/minimalistV2/components/Avatar.qml
+++ b/themes/minimalistV2/components/Avatar.qml
@@ -12,6 +12,7 @@ Item {
     property var onSwitchUser: null
     // Calculate actual visual dimensions based on the shape bounds
     readonly property var bounds: bgShape.bounds
+    property real hoverBoost: avatarHover.containsMouse ? 0.05 : 0
 
     onCurrentUserIndexChanged: {
         if (avatarImage.status !== Image.Null)
@@ -21,17 +22,7 @@ Item {
     implicitWidth: Theme.avatarFrameSize
     implicitHeight: Theme.avatarShape === "clamshell" ? 220 : Theme.avatarFrameSize
     clip: true
-
-    property real hoverBoost: avatarHover.containsMouse ? 0.05 : 0
-    scale: 1.0 + root.hoverBoost + avatarBounce.bounce
-
-    Behavior on hoverBoost {
-        NumberAnimation {
-            duration: Theme.animDurationFast
-            easing.type: Easing.OutCubic
-        }
-
-    }
+    scale: 1 + root.hoverBoost + avatarBounce.bounce
 
     TapBounce {
         id: avatarBounce
@@ -144,6 +135,13 @@ Item {
             if (root.onSwitchUser)
                 root.onSwitchUser();
 
+        }
+    }
+
+    Behavior on hoverBoost {
+        NumberAnimation {
+            duration: Theme.animDurationFast
+            easing.type: Easing.OutCubic
         }
 
     }

--- a/themes/minimalistV2/components/Clock.qml
+++ b/themes/minimalistV2/components/Clock.qml
@@ -4,9 +4,7 @@ import QtQuick 2.15
 Column {
     id: root
 
-    spacing: -12
-
-    property real centerScale: 0.90
+    property real centerScale: 0.9
     property date currentTime: new Date()
     readonly property var fontAxesHours: ({
         "wght": 500,
@@ -26,6 +24,8 @@ Column {
         "ROND": 25,
         "opsz": 7
     })
+
+    spacing: -12
 
     Timer {
         interval: 1000

--- a/themes/minimalistV2/components/LoginCard.qml
+++ b/themes/minimalistV2/components/LoginCard.qml
@@ -185,7 +185,6 @@ Item {
                                 root.onRestoreFocus();
 
                         }
-
                     }
                 }
 
@@ -212,7 +211,7 @@ Item {
                         font.variableAxes: userSessionRow.textAxes
                         color: userMouseArea.containsMouse ? Theme.mOnSurface : Theme.mPrimary
                         text: root.getUserName(root.currentUserIndex)
-                        scale: 1.0 + userBounce.bounce
+                        scale: 1 + userBounce.bounce
 
                         TapBounce {
                             id: userBounce
@@ -259,7 +258,7 @@ Item {
                         font.variableAxes: userSessionRow.textAxes
                         color: sessionMouseArea.containsMouse ? Theme.mOnSurface : Theme.mPrimary
                         text: root.getSessionName(root.currentSessionIndex)
-                        scale: 1.0 + sessionBounce.bounce
+                        scale: 1 + sessionBounce.bounce
 
                         TapBounce {
                             id: sessionBounce

--- a/themes/minimalistV2/components/PasswordInput.qml
+++ b/themes/minimalistV2/components/PasswordInput.qml
@@ -21,7 +21,6 @@ Item {
 
         lastLength = buffer.length;
     }
-
     implicitWidth: 365
     implicitHeight: 48
 
@@ -238,41 +237,15 @@ Item {
                     model: root.buffer.length
 
                     delegate: ShapeCanvas {
-                        implicitWidth: 15
-                        implicitHeight: 15
-                        color: Theme.mOnSurface
-                        opacity: 1.0
-
                         property bool isNew: index === dots.currentIndex
                         property int shapeIndex: isNew ? Math.floor(Math.random() * 4) + 1 : 0
                         property var shapeGetters: [MaterialShapes.getCircle, MaterialShapes.getGem, MaterialShapes.getSunny, MaterialShapes.getCookie4Sided, MaterialShapes.getCookie6Sided, MaterialShapes.getVerySunny]
+
+                        implicitWidth: 15
+                        implicitHeight: 15
+                        color: Theme.mOnSurface
+                        opacity: 1
                         roundedPolygon: shapeGetters[shapeIndex]()
-
-                        SequentialAnimation on scale {
-                            running: isNew
-                            NumberAnimation {
-                                from: 0
-                                to: 1.4
-                                duration: 180
-                                easing.type: Easing.OutCubic
-                            }
-
-                            NumberAnimation {
-                                to: 1.0
-                                duration: 150
-                            }
-
-                        }
-
-                        SequentialAnimation on opacity {
-                            running: isNew
-                            NumberAnimation {
-                                from: 0
-                                to: 1
-                                duration: 200
-                            }
-
-                        }
 
                         Timer {
                             id: timerShape
@@ -281,6 +254,34 @@ Item {
                             repeat: false
                             running: isNew
                             onTriggered: shapeIndex = 0
+                        }
+
+                        SequentialAnimation on scale {
+                            running: isNew
+
+                            NumberAnimation {
+                                from: 0
+                                to: 1.4
+                                duration: 180
+                                easing.type: Easing.OutCubic
+                            }
+
+                            NumberAnimation {
+                                to: 1
+                                duration: 150
+                            }
+
+                        }
+
+                        SequentialAnimation on opacity {
+                            running: isNew
+
+                            NumberAnimation {
+                                from: 0
+                                to: 1
+                                duration: 200
+                            }
+
                         }
 
                     }

--- a/themes/minimalistV2/components/PowerButton.qml
+++ b/themes/minimalistV2/components/PowerButton.qml
@@ -15,7 +15,7 @@ Button {
     implicitHeight: 64
     hoverEnabled: true
     focusPolicy: Qt.ClickFocus
-    scale: 1.0 + buttonBounce.bounce
+    scale: 1 + buttonBounce.bounce
     onClicked: {
         buttonBounce.trigger();
         if (onClickedAction)

--- a/themes/minimalistV2/components/TapBounce.qml
+++ b/themes/minimalistV2/components/TapBounce.qml
@@ -10,7 +10,6 @@ Item {
 
     function trigger() {
         bounceAnim.restart();
-
     }
 
     SequentialAnimation {

--- a/themes/minimalistV2/components/shapes/ShapeCanvas.qml
+++ b/themes/minimalistV2/components/shapes/ShapeCanvas.qml
@@ -20,7 +20,7 @@ Canvas {
     // Internals: anim
     property var prevRoundedPolygon: null
     property double progress: 1
-    property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)
+    property var morph: null
     property Animation animation: NumberAnimation {
         duration: 350
         easing.type: Easing.BezierSpline

--- a/themes/minimalistV2/components/shapes/ShapeCanvas.qml
+++ b/themes/minimalistV2/components/shapes/ShapeCanvas.qml
@@ -3,6 +3,7 @@ import "shapes/morph.js" as Morph
 
 Canvas {
     id: root
+
     property color color: "#685496"
     property var roundedPolygon: null
     property bool polygonIsNormalized: true
@@ -11,22 +12,22 @@ Canvas {
     property bool debug: false
     property real xOffset: 0
     property real yOffset: 0
-
     // Internals: size
     property var bounds: roundedPolygon.calculateBounds()
-    implicitWidth: bounds[2] - bounds[0]
-    implicitHeight: bounds[3] - bounds[1]
-
     // Internals: anim
     property var prevRoundedPolygon: null
     property double progress: 1
     property var morph: null
-    property Animation animation: NumberAnimation {
+    property Animation animation
+
+    animation: NumberAnimation {
         duration: 350
         easing.type: Easing.BezierSpline
-        easing.bezierCurve: [0.42, 1.67, 0.21, 0.90, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
+        easing.bezierCurve: [0.42, 1.67, 0.21, 0.9, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
     }
 
+    implicitWidth: bounds[2] - bounds[0]
+    implicitHeight: bounds[3] - bounds[1]
     onRoundedPolygonChanged: {
         delete root.morph;
         root.morph = new Morph.Morph(root.prevRoundedPolygon ?? root.roundedPolygon, root.roundedPolygon);
@@ -36,12 +37,6 @@ Canvas {
         root.progress = 1;
         root.prevRoundedPolygon = root.roundedPolygon;
     }
-
-    Behavior on progress {
-        id: morphBehavior
-        animation: root.animation
-    }
-
     onProgressChanged: requestPaint()
     onColorChanged: requestPaint()
     onBorderWidthChanged: requestPaint()
@@ -49,24 +44,23 @@ Canvas {
     onDebugChanged: requestPaint()
     onXOffsetChanged: requestPaint()
     onYOffsetChanged: requestPaint()
-
     onPaint: {
         var ctx = getContext("2d");
         ctx.fillStyle = root.color;
         ctx.clearRect(0, 0, width, height);
         if (!root.morph)
-            return;
+            return ;
+
         const cubics = root.morph.asCubics(root.progress);
         if (cubics.length === 0)
-            return;
+            return ;
+
         const size = Math.min(root.width, root.height);
-
         ctx.save();
-        if (root.polygonIsNormalized) {
+        if (root.polygonIsNormalized)
             ctx.scale(size, size);
-        }
-        ctx.translate(root.xOffset, root.yOffset);
 
+        ctx.translate(root.xOffset, root.yOffset);
         ctx.beginPath();
         ctx.moveTo(cubics[0].anchor0X, cubics[0].anchor0Y);
         for (const cubic of cubics) {
@@ -74,30 +68,27 @@ Canvas {
         }
         ctx.closePath();
         ctx.fill();
-
         if (root.borderWidth > 0) {
             ctx.strokeStyle = root.borderColor;
             ctx.lineWidth = root.borderWidth;
             ctx.stroke();
         }
-
         if (root.debug) {
             const points = [];
             for (let i = 0; i < cubics.length; ++i) {
                 const c = cubics[i];
                 if (i === 0)
                     points.push({
-                        x: c.anchor0X,
-                        y: c.anchor0Y
-                    });
+                    "x": c.anchor0X,
+                    "y": c.anchor0Y
+                });
+
                 points.push({
-                    x: c.anchor1X,
-                    y: c.anchor1Y
+                    "x": c.anchor1X,
+                    "y": c.anchor1Y
                 });
             }
-
             let radius = 2;
-
             ctx.fillStyle = "red";
             for (const p of points) {
                 ctx.beginPath();
@@ -105,7 +96,13 @@ Canvas {
                 ctx.fill();
             }
         }
-
         ctx.restore();
     }
+
+    Behavior on progress {
+        id: morphBehavior
+
+        animation: root.animation
+    }
+
 }

--- a/themes/minimalistV2/singletons/Theme.qml
+++ b/themes/minimalistV2/singletons/Theme.qml
@@ -10,7 +10,7 @@ QtObject {
     property real avatarFrameSize: {
         if (theme.avatarShape === "clamshell")
             return 300;
-        
+
         if (theme.avatarShape === "circle")
             return 240;
 
@@ -19,7 +19,6 @@ QtObject {
     property real avatarInset: 19
     property string _randomAvatarShape: {
         var shapes = ["circle", "clamshell", "cookie"];
-
         return shapes[Math.floor(Math.random() * shapes.length)];
     }
     property string avatarShape: {


### PR DESCRIPTION
ShapeCanvas.morph was initialised with a property binding:

`property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)`

Two problems with this:

1. It references roundedPolygon, so QML keeps it as a live binding and re-evaluates it on every change. But onRoundedPolygonChanged also assigns root.morph imperatively, so the binding and the handler fight over the same property. The engine logs a flood of "QML ShapeCanvas: Overwriting binding on ShapeCanvas::morph ..." and re-evaluates constantly. On the login screen, where the password dots and avatar shapes drive roundedPolygon. this leaves the greeter sitting at 40–170% CPU while idle (hot, loud laptop).

2. The initial value is pointless anyway: a Morph from a polygon to itself is an identity that animates nothing, and onRoundedPolygonChanged immediately replaces it with the real prev→current Morph before the first meaningful paint.

Initialise morph to null instead. onRoundedPolygonChanged sets it on the first real shape, and onPaint already guards `if (!morph)`, so rendering is unchanged. The binding/imperative conflict, the warning spam and the busy-loop are gone.

Fixed in both minimalistV2 and locklike (byte-identical file, same bug).