### PR TITLE
fix(shapes): stop morph binding loop pinning the CPU on the greeter

### DIFF
--- a/themes/locklike/components/shapes/ShapeCanvas.qml
+++ b/themes/locklike/components/shapes/ShapeCanvas.qml
@@ -3,6 +3,7 @@ import "shapes/morph.js" as Morph
 
 Canvas {
     id: root
+
     property color color: "#685496"
     property var roundedPolygon: null
     property bool polygonIsNormalized: true
@@ -11,22 +12,22 @@ Canvas {
     property bool debug: false
     property real xOffset: 0
     property real yOffset: 0
-
     // Internals: size
     property var bounds: roundedPolygon.calculateBounds()
-    implicitWidth: bounds[2] - bounds[0]
-    implicitHeight: bounds[3] - bounds[1]
-
     // Internals: anim
     property var prevRoundedPolygon: null
     property double progress: 1
-    property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)
-    property Animation animation: NumberAnimation {
+    property var morph: null
+    property Animation animation
+
+    animation: NumberAnimation {
         duration: 350
         easing.type: Easing.BezierSpline
-        easing.bezierCurve: [0.42, 1.67, 0.21, 0.90, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
+        easing.bezierCurve: [0.42, 1.67, 0.21, 0.9, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
     }
 
+    implicitWidth: bounds[2] - bounds[0]
+    implicitHeight: bounds[3] - bounds[1]
     onRoundedPolygonChanged: {
         delete root.morph;
         root.morph = new Morph.Morph(root.prevRoundedPolygon ?? root.roundedPolygon, root.roundedPolygon);
@@ -36,12 +37,6 @@ Canvas {
         root.progress = 1;
         root.prevRoundedPolygon = root.roundedPolygon;
     }
-
-    Behavior on progress {
-        id: morphBehavior
-        animation: root.animation
-    }
-
     onProgressChanged: requestPaint()
     onColorChanged: requestPaint()
     onBorderWidthChanged: requestPaint()
@@ -49,24 +44,23 @@ Canvas {
     onDebugChanged: requestPaint()
     onXOffsetChanged: requestPaint()
     onYOffsetChanged: requestPaint()
-
     onPaint: {
         var ctx = getContext("2d");
         ctx.fillStyle = root.color;
         ctx.clearRect(0, 0, width, height);
         if (!root.morph)
-            return;
+            return ;
+
         const cubics = root.morph.asCubics(root.progress);
         if (cubics.length === 0)
-            return;
+            return ;
+
         const size = Math.min(root.width, root.height);
-
         ctx.save();
-        if (root.polygonIsNormalized) {
+        if (root.polygonIsNormalized)
             ctx.scale(size, size);
-        }
-        ctx.translate(root.xOffset, root.yOffset);
 
+        ctx.translate(root.xOffset, root.yOffset);
         ctx.beginPath();
         ctx.moveTo(cubics[0].anchor0X, cubics[0].anchor0Y);
         for (const cubic of cubics) {
@@ -74,30 +68,27 @@ Canvas {
         }
         ctx.closePath();
         ctx.fill();
-
         if (root.borderWidth > 0) {
             ctx.strokeStyle = root.borderColor;
             ctx.lineWidth = root.borderWidth;
             ctx.stroke();
         }
-
         if (root.debug) {
             const points = [];
             for (let i = 0; i < cubics.length; ++i) {
                 const c = cubics[i];
                 if (i === 0)
                     points.push({
-                        x: c.anchor0X,
-                        y: c.anchor0Y
-                    });
+                    "x": c.anchor0X,
+                    "y": c.anchor0Y
+                });
+
                 points.push({
-                    x: c.anchor1X,
-                    y: c.anchor1Y
+                    "x": c.anchor1X,
+                    "y": c.anchor1Y
                 });
             }
-
             let radius = 2;
-
             ctx.fillStyle = "red";
             for (const p of points) {
                 ctx.beginPath();
@@ -105,7 +96,13 @@ Canvas {
                 ctx.fill();
             }
         }
-
         ctx.restore();
     }
+
+    Behavior on progress {
+        id: morphBehavior
+
+        animation: root.animation
+    }
+
 }

--- a/themes/minimalistV2/components/shapes/ShapeCanvas.qml
+++ b/themes/minimalistV2/components/shapes/ShapeCanvas.qml
@@ -3,6 +3,7 @@ import "shapes/morph.js" as Morph
 
 Canvas {
     id: root
+
     property color color: "#685496"
     property var roundedPolygon: null
     property bool polygonIsNormalized: true
@@ -11,22 +12,22 @@ Canvas {
     property bool debug: false
     property real xOffset: 0
     property real yOffset: 0
-
     // Internals: size
     property var bounds: roundedPolygon.calculateBounds()
-    implicitWidth: bounds[2] - bounds[0]
-    implicitHeight: bounds[3] - bounds[1]
-
     // Internals: anim
     property var prevRoundedPolygon: null
     property double progress: 1
-    property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)
-    property Animation animation: NumberAnimation {
+    property var morph: null
+    property Animation animation
+
+    animation: NumberAnimation {
         duration: 350
         easing.type: Easing.BezierSpline
-        easing.bezierCurve: [0.42, 1.67, 0.21, 0.90, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
+        easing.bezierCurve: [0.42, 1.67, 0.21, 0.9, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
     }
 
+    implicitWidth: bounds[2] - bounds[0]
+    implicitHeight: bounds[3] - bounds[1]
     onRoundedPolygonChanged: {
         delete root.morph;
         root.morph = new Morph.Morph(root.prevRoundedPolygon ?? root.roundedPolygon, root.roundedPolygon);
@@ -36,12 +37,6 @@ Canvas {
         root.progress = 1;
         root.prevRoundedPolygon = root.roundedPolygon;
     }
-
-    Behavior on progress {
-        id: morphBehavior
-        animation: root.animation
-    }
-
     onProgressChanged: requestPaint()
     onColorChanged: requestPaint()
     onBorderWidthChanged: requestPaint()
@@ -49,24 +44,23 @@ Canvas {
     onDebugChanged: requestPaint()
     onXOffsetChanged: requestPaint()
     onYOffsetChanged: requestPaint()
-
     onPaint: {
         var ctx = getContext("2d");
         ctx.fillStyle = root.color;
         ctx.clearRect(0, 0, width, height);
         if (!root.morph)
-            return;
+            return ;
+
         const cubics = root.morph.asCubics(root.progress);
         if (cubics.length === 0)
-            return;
+            return ;
+
         const size = Math.min(root.width, root.height);
-
         ctx.save();
-        if (root.polygonIsNormalized) {
+        if (root.polygonIsNormalized)
             ctx.scale(size, size);
-        }
-        ctx.translate(root.xOffset, root.yOffset);
 
+        ctx.translate(root.xOffset, root.yOffset);
         ctx.beginPath();
         ctx.moveTo(cubics[0].anchor0X, cubics[0].anchor0Y);
         for (const cubic of cubics) {
@@ -74,30 +68,27 @@ Canvas {
         }
         ctx.closePath();
         ctx.fill();
-
         if (root.borderWidth > 0) {
             ctx.strokeStyle = root.borderColor;
             ctx.lineWidth = root.borderWidth;
             ctx.stroke();
         }
-
         if (root.debug) {
             const points = [];
             for (let i = 0; i < cubics.length; ++i) {
                 const c = cubics[i];
                 if (i === 0)
                     points.push({
-                        x: c.anchor0X,
-                        y: c.anchor0Y
-                    });
+                    "x": c.anchor0X,
+                    "y": c.anchor0Y
+                });
+
                 points.push({
-                    x: c.anchor1X,
-                    y: c.anchor1Y
+                    "x": c.anchor1X,
+                    "y": c.anchor1Y
                 });
             }
-
             let radius = 2;
-
             ctx.fillStyle = "red";
             for (const p of points) {
                 ctx.beginPath();
@@ -105,7 +96,13 @@ Canvas {
                 ctx.fill();
             }
         }
-
         ctx.restore();
     }
+
+    Behavior on progress {
+        id: morphBehavior
+
+        animation: root.animation
+    }
+
 }


### PR DESCRIPTION
ShapeCanvas.morph was initialised with a property binding:

`property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)`

Two problems with this:

1. It references roundedPolygon, so QML keeps it as a live binding and re-evaluates it on every change. But onRoundedPolygonChanged also assigns root.morph imperatively, so the binding and the handler fight over the same property. The engine logs a flood of "QML ShapeCanvas: Overwriting binding on ShapeCanvas::morph ..." and re-evaluates constantly. On the login screen, where the password dots and avatar shapes drive roundedPolygon, this leaves the greeter sitting at 40-170% CPU while idle (hot, loud laptop).

2. The initial value is pointless anyway: a Morph from a polygon to itself is an identity that animates nothing, and onRoundedPolygonChanged immediately replaces it with the real prev->current Morph before the first meaningful paint.

Initialise morph to **`null`** instead. onRoundedPolygonChanged sets it on the first real shape, and onPaint already guards `if (!morph)`, so rendering is unchanged. The binding/imperative conflict, the warning spam and the busy-loop are gone.

Fixed in both minimalistV2 and locklike (byte-identical file, same bug). Formatted with ./scripts/dev/format.sh -i, scoped to these two files.